### PR TITLE
Validates dataset.json against schema file

### DIFF
--- a/documentation/dataset_conversion.md
+++ b/documentation/dataset_conversion.md
@@ -132,7 +132,7 @@ Here is the content of the dataset.json from the Prostate task:
      "description": "Prostate transitional zone and peripheral zone segmentation",
      "reference": "Radboud University, Nijmegen Medical Centre",
      "licence":"CC-BY-SA 4.0",
-     "relase":"1.0 04/05/2018",
+     "release":"1.0 04/05/2018",
      "tensorImageSize": "4D",
      "modality": { 
        "0": "T2", 
@@ -150,7 +150,7 @@ Here is the content of the dataset.json from the Prostate task:
      }
 
 Note that we truncated the "training" and "test" lists for clarity. You need to specify all the cases in there. If you 
-don't have test images (imagesTs does not exist) you can leave "test" blank: `"test": []`.
+don't have test images (imagesTs does not exist) you can leave "test" blank: `"test": []`. See the [json schema file](../nnunet/preprocessing/schema.json) for more information regarding dataset.json.
 
 Please also have a look at the python files located [here](../nnunet/dataset_conversion). They show how we created our 
 custom dataset.jsons for a range of public datasets.

--- a/nnunet/preprocessing/schema.json
+++ b/nnunet/preprocessing/schema.json
@@ -1,0 +1,158 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "http://example.com/example.json",
+  "type": "object",
+  "title": "The Root Schema",
+  "description": "The root schema for the dataset.json file.",
+  "required": [
+    "name",
+    "description",
+    "reference",
+    "licence",
+    "release",
+    "tensorImageSize",
+    "modality",
+    "labels",
+    "numTraining",
+    "numTest",
+    "training",
+    "test"
+  ],
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "Dataset name.",
+      "default": "",
+      "example": "PROSTATE"
+    },
+    "description": {
+      "type": "string",
+      "description": "A general textual description of the dataset.",
+      "default": "",
+      "example": "Prostate transitional zone and peripheral zone segmentation."
+    },
+    "reference": {
+      "type": "string",
+      "description": "Citation or data source.",
+      "default": "",
+      "example": "Radboud University, Nijmegen Medical Centre"
+    },
+    "licence": {
+      "type": "string",
+      "description": "Licence information",
+      "default": "",
+      "example": "CC-BY-SA 4.0"
+    },
+    "release": {
+      "type": "string",
+      "description": "Release version information.",
+      "default": "",
+      "example": "v1.2"
+    },
+    "tensorImageSize": {
+      "type": "string",
+      "description": "TODO: Needs explaination.",
+      "default": "",
+      "example": "4D"
+    },
+    "modality": {
+      "type": "object",
+      "description": "An object mapping the modality identifier (key) to the modality name (value). Should have at least a '0' modality",
+      "default": {},
+      "example": {
+        "0": "T2",
+        "1": "ADC"
+      },
+      "required": ["0"],
+      "additionalProperties": true,
+      "properties": {
+        "0": {
+          "type": "string",
+          "description": "A required base modality",
+          "default": "",
+          "example": "T1"
+        }
+      }
+    },
+    "labels": {
+      "type": "object",
+      "description": "Labels to be segmented. At least a background (0) and foreground (1) are required.",
+      "default": {},
+      "example": {
+        "0": "background",
+        "1": "tumor"
+      },
+      "required": ["0", "1"],
+      "additionalProperties": true,
+      "properties": {
+        "0": {
+          "type": "string",
+          "description": "Background label value.",
+          "default": "",
+          "example": "background"
+        },
+        "1": {
+          "type": "string",
+          "description": "Region-of-interest label value.",
+          "default": "",
+          "example": "tumor"
+        }
+      }
+    },
+    "numTraining": {
+      "type": "integer",
+      "description": "Number of training samples. TODO: minimum number of training samples?",
+      "default": 0,
+      "example": 125
+    },
+    "numTest": {
+      "type": "integer",
+      "description": "Number of testing samples. TODO: minimum number of testing samples?",
+      "default": 0,
+      "example": 32
+    },
+    "training": {
+      "type": "array",
+      "description": "An array of objects containing 2 keys for image and corresponding label. TODO: minimum number of training samples?",
+      "minItems": 0,
+      "default": [],
+      "items": {
+        "type": "object",
+        "description": "Object for every given training sample.",
+        "default": {},
+        "example": {
+          "image": "./imagesTr/TASK_ID1.nii.gz",
+          "label": "./labelsTr/TASK_ID1.nii.gz"
+        },
+        "required": ["image", "label"],
+        "additionalProperties": false,
+        "properties": {
+          "image": {
+            "type": "string",
+            "description": "Relative path to image.",
+            "default": "",
+            "example": "./imagesTr/TASK_ID1.nii.gz"
+          },
+          "label": {
+            "type": "string",
+            "description": "Relative path to label.",
+            "default": "",
+            "example": "./labelsTr/TASK_ID1.nii.gz"
+          }
+        }
+      }
+    },
+    "test": {
+      "type": "array",
+      "minItems": 0,
+      "description": "An array of paths to test images.  TODO: minimum number of testing samples?",
+      "default": [],
+      "items": {
+        "type": "string",
+        "description": "Path to test image. Test labels are not linked here.",
+        "default": "",
+        "example": "./imagesTs/TASK_ID2.nii.gz"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Example [here](https://github.com/MIC-DKFZ/nnUNet/blob/master/documentation/dataset_conversion.md) validates against schema.

Uses jsonschema which doesn't come out of the box with python, but I found it in my container (a dependency to some other lib required here). Can also be added it to requirements.txt for completeness..