### PR TITLE
Make sure output directory exists before plotting network architecture

### DIFF
--- a/nnunet/training/network_training/network_trainer.py
+++ b/nnunet/training/network_training/network_trainer.py
@@ -411,14 +411,13 @@ class NetworkTrainer(object):
 
         self._maybe_init_amp()
 
+        maybe_mkdir_p(self.output_folder)        
         self.plot_network_architecture()
 
         if cudnn.benchmark and cudnn.deterministic:
             warn("torch.backends.cudnn.deterministic is True indicating a deterministic training is desired. "
                  "But torch.backends.cudnn.benchmark is True as well and this will prevent deterministic training! "
                  "If you want deterministic then set benchmark=False")
-
-        maybe_mkdir_p(self.output_folder)
 
         if not self.was_initialized:
             self.initialize(True)


### PR DESCRIPTION
I always get the following error message when starting the training:

> Command '['dot', '-Tpdf', '-O', 'network_architecture']' returned non-zero exit status 2. [stderr: b"Error: dot: can't open network_architecture\n"]

It seems like the `maybe_mkdir_p` command in [network_trainer.py](https://github.com/MIC-DKFZ/nnUNet/blob/200e827c65020bb255ac3076e64ff505f86c4a5e/nnunet/training/network_training/network_trainer.py#L421) should be called before the `plot_network_architecture()` method.