### PR TITLE
Add `requests` as dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(name='nnunet',
             "sklearn",
             "SimpleITK",
             "pandas",
+            "requests",
             "nibabel", 'tifffile'
       ],
       entry_points={


### PR DESCRIPTION
The `nnUNet_download_pretrained_model` command requires `requests` to download.