### PR TITLE
#478: Use Python build-in unzip instead of shell

### DIFF
--- a/documentation/common_problems_and_solutions.md
+++ b/documentation/common_problems_and_solutions.md
@@ -60,6 +60,12 @@ make sure to use the most recent nnU-Net version (we constantly try to improve t
 you can always download the zip file from our zenodo (https://zenodo.org/record/4003545) and use the 
 `nnUNet_install_pretrained_model_from_zip` command to install the model.
 
+## Downloading pre-trained models: `unzip: 'unzip' is not recognized as an internal or external command` OR `Command 'unzip' not found`
+
+On Windows systems and on a bare WSL2 system, the `unzip` command may not be present.
+Either install it, unzip the pre-trained model from zenodo download, or update to a newer version of nnUNet that uses the Python build in
+(https://docs.python.org/3/library/zipfile.html)
+
 ## nnU-Net training (2D U-Net): High (and increasing) system RAM usage, OOM
 
 There was a issue with mixed precision causing a system RAM memory leak. This is fixed when using cuDNN 8.0.2 or newer, 

--- a/nnunet/inference/pretrained_models/download_pretrained_model.py
+++ b/nnunet/inference/pretrained_models/download_pretrained_model.py
@@ -15,6 +15,7 @@ import shutil
 import tempfile
 from time import time
 from urllib.request import urlopen
+import zipfile
 
 from batchgenerators.utilities.file_and_folder_operations import join, isfile
 
@@ -261,7 +262,8 @@ def download_file(url, local_filename):
 
 
 def install_model_from_zip_file(zip_file: str):
-    call(['unzip', '-o', '-d', network_training_output_dir, zip_file])
+    with zipfile.ZipFile(zip_file, 'r') as zip_ref:
+        zip_ref.extractall(network_training_output_dir)
 
 
 def print_license_warning():


### PR DESCRIPTION
Shell unzip causes problems on:

1. A very bare WSL2 - unzip is not installed by default.
2. Windows itself

Therefore, I rewrote the unzip function to use Python's ZipFile.

----

Test: this worked on Windows!

1. Create a virtual environment .venv and activate it
2. python -m setup.py install
3. set RESULTS_FOLDER=D:\pre-trained\ 
4. .venv\Scripts\nnUNet_download_pretrained_model.exe Task114_heart_MNMs
5. Check the output directory:
 (.venv) D:\pre-trained\nnUNet\3d_fullres\Task114_heart_MNMs\nnUNetTrainerV2_MMS__nnUNetPlansv2.1>
6. fold_0,1,2,3,4 and plans.pkl, postprocessing.json exist.