### PR TITLE
Change default number of multiprocessing cores

### DIFF
--- a/nnunet/configuration.py
+++ b/nnunet/configuration.py
@@ -1,5 +1,8 @@
 import os
+import psutil
 
-default_num_threads = 8 if 'nnUNet_def_n_proc' not in os.environ else int(os.environ['nnUNet_def_n_proc'])
+default_num_threads = max(1, psutil.cpu_count(logical=False) - 1)
+if 'nnUNet_def_n_proc' in os.environ:
+    default_num_threads = int(os.environ['nnUNet_def_n_proc'])
 RESAMPLING_SEPARATE_Z_ANISO_THRESHOLD = 3  # determines what threshold to use for resampling the low resolution axis
 # separately (with NN)


### PR DESCRIPTION
Hi @FabianIsensee 
after having multiple crashes on our cluster (submission to different types of machines) due to the default value of 8 cores independently on the machine. I propose this way to use as default one core less than the number of physical cores (cf. here):
https://stackoverflow.com/questions/64837376/how-to-efficiently-run-multiple-pytorch-processes-models-at-once-traceback

It performed well across all machines for me.

Feel free to merge or discard it ;-)