### PR TITLE
NeuralNetwork class now compares the parameter.device.type to "cpu" i…

### DIFF
--- a/nnunet/network_architecture/neural_network.py
+++ b/nnunet/network_architecture/neural_network.py
@@ -30,7 +30,7 @@ class NeuralNetwork(nn.Module):
         super(NeuralNetwork, self).__init__()
 
     def get_device(self):
-        if next(self.parameters()).device == "cpu":
+        if next(self.parameters()).device.type == "cpu":
             return "cpu"
         else:
             return next(self.parameters()).device.index


### PR DESCRIPTION
…nstead of the device object which is erronously used. This leads to correct error message getting thrown.