### PR TITLE
Allow image modalities that are not numbered consecutively

### DIFF
--- a/nnunet/experiment_planning/experiment_planner_baseline_3DUNet.py
+++ b/nnunet/experiment_planning/experiment_planner_baseline_3DUNet.py
@@ -361,10 +361,10 @@ class ExperimentPlanner(object):
         modalities = self.dataset_properties['modalities']
         num_modalities = len(list(modalities.keys()))
 
-        for i in range(num_modalities):
-            if modalities[i] == "CT" or modalities[i] == 'ct':
+        for i, mod in modalities.items():
+            if mod == "CT" or mod == 'ct':
                 schemes[i] = "CT"
-            elif modalities[i] == 'noNorm':
+            elif mod == 'noNorm':
                 schemes[i] = "noNorm"
             else:
                 schemes[i] = "nonCT"
@@ -387,8 +387,8 @@ class ExperimentPlanner(object):
         num_modalities = len(list(modalities.keys()))
         use_nonzero_mask_for_norm = OrderedDict()
 
-        for i in range(num_modalities):
-            if "CT" in modalities[i]:
+        for i, mod in modalities.items():
+            if "CT" in mod:
                 use_nonzero_mask_for_norm[i] = False
             else:
                 all_size_reductions = []

--- a/nnunet/experiment_planning/utils.py
+++ b/nnunet/experiment_planning/utils.py
@@ -87,14 +87,15 @@ def create_lists_from_splitted_dataset(base_folder_splitted):
         d = json.load(jsn)
         training_files = d['training']
     num_modalities = len(d['modality'].keys())
+    modalities = d['modality']
     for tr in training_files:
         cur_pat = []
-        for mod in range(num_modalities):
+        for mod in modalities:
             cur_pat.append(join(base_folder_splitted, "imagesTr", tr['image'].split("/")[-1][:-7] +
-                                "_%04.0d.nii.gz" % mod))
+                f"_{int(mod):04d}.nii.gz"))
         cur_pat.append(join(base_folder_splitted, "labelsTr", tr['label'].split("/")[-1]))
         lists.append(cur_pat)
-    return lists, {int(i): d['modality'][str(i)] for i in d['modality'].keys()}
+    return lists, {int(i): d['modality'][str(i)] for i in modalities}
 
 
 def create_lists_from_splitted_dataset_folder(folder):

--- a/nnunet/inference/predict.py
+++ b/nnunet/inference/predict.py
@@ -565,7 +565,8 @@ def predict_cases_fastest(model, list_of_lists, output_filenames, folds, num_thr
     pool.join()
 
 
-def check_input_folder_and_return_caseIDs(input_folder, expected_num_modalities):
+def check_input_folder_and_return_caseIDs(input_folder, expected_modalities):
+    expected_num_modalities = len(expected_modalities)
     print("This model expects %d input modalities for each image" % expected_num_modalities)
     files = subfiles(input_folder, suffix=".nii.gz", join=False, sort=True)
 
@@ -578,8 +579,8 @@ def check_input_folder_and_return_caseIDs(input_folder, expected_num_modalities)
 
     # now check if all required files are present and that no unexpected files are remaining
     for c in maybe_case_ids:
-        for n in range(expected_num_modalities):
-            expected_output_file = c + "_%04.0d.nii.gz" % n
+        for n in expected_modalities:
+            expected_output_file = f"{c}_{n:04d}.nii.gz"
             if not isfile(join(input_folder, expected_output_file)):
                 missing.append(expected_output_file)
             else:
@@ -631,9 +632,10 @@ def predict_from_folder(model: str, input_folder: str, output_folder: str, folds
 
     assert isfile(join(model, "plans.pkl")), "Folder with saved model weights must contain a plans.pkl file"
     expected_num_modalities = load_pickle(join(model, "plans.pkl"))['num_modalities']
+    expected_modalities = load_pickle(join(model, "plans.pkl"))['modalities']
 
     # check input folder integrity
-    case_ids = check_input_folder_and_return_caseIDs(input_folder, expected_num_modalities)
+    case_ids = check_input_folder_and_return_caseIDs(input_folder, expected_modalities)
 
     output_files = [join(output_folder, i + ".nii.gz") for i in case_ids]
     all_files = subfiles(input_folder, suffix=".nii.gz", join=False, sort=True)

--- a/nnunet/preprocessing/preprocessing.py
+++ b/nnunet/preprocessing/preprocessing.py
@@ -271,35 +271,35 @@ class GenericPreprocessor(object):
         assert len(self.use_nonzero_mask) == len(data), "self.use_nonzero_mask must have as many entries as data" \
                                                         " has modalities"
 
-        for c in range(len(data)):
-            scheme = self.normalization_scheme_per_modality[c]
+        for c, mod_id in enumerate(self.normalization_scheme_per_modality):
+            scheme = self.normalization_scheme_per_modality[mod_id]
             if scheme == "CT":
                 # clip to lb and ub from train data foreground and use foreground mn and sd from training data
                 assert self.intensityproperties is not None, "ERROR: if there is a CT then we need intensity properties"
-                mean_intensity = self.intensityproperties[c]['mean']
-                std_intensity = self.intensityproperties[c]['sd']
-                lower_bound = self.intensityproperties[c]['percentile_00_5']
-                upper_bound = self.intensityproperties[c]['percentile_99_5']
+                mean_intensity = self.intensityproperties[mod_id]['mean']
+                std_intensity = self.intensityproperties[mod_id]['sd']
+                lower_bound = self.intensityproperties[mod_id]['percentile_00_5']
+                upper_bound = self.intensityproperties[mod_id]['percentile_99_5']
                 data[c] = np.clip(data[c], lower_bound, upper_bound)
                 data[c] = (data[c] - mean_intensity) / std_intensity
-                if use_nonzero_mask[c]:
+                if use_nonzero_mask[mod_id]:
                     data[c][seg[-1] < 0] = 0
             elif scheme == "CT2":
                 # clip to lb and ub from train data foreground, use mn and sd form each case for normalization
                 assert self.intensityproperties is not None, "ERROR: if there is a CT then we need intensity properties"
-                lower_bound = self.intensityproperties[c]['percentile_00_5']
-                upper_bound = self.intensityproperties[c]['percentile_99_5']
+                lower_bound = self.intensityproperties[mod_id]['percentile_00_5']
+                upper_bound = self.intensityproperties[mod_id]['percentile_99_5']
                 mask = (data[c] > lower_bound) & (data[c] < upper_bound)
                 data[c] = np.clip(data[c], lower_bound, upper_bound)
                 mn = data[c][mask].mean()
                 sd = data[c][mask].std()
                 data[c] = (data[c] - mn) / sd
-                if use_nonzero_mask[c]:
+                if use_nonzero_mask[mod_id]:
                     data[c][seg[-1] < 0] = 0
             elif scheme == 'noNorm':
                 pass
             else:
-                if use_nonzero_mask[c]:
+                if use_nonzero_mask[mod_id]:
                     mask = seg[-1] >= 0
                     data[c][mask] = (data[c][mask] - data[c][mask].mean()) / (data[c][mask].std() + 1e-8)
                     data[c][mask == 0] = 0
@@ -446,35 +446,35 @@ class Preprocessor3DDifferentResampling(GenericPreprocessor):
         assert len(self.use_nonzero_mask) == len(data), "self.use_nonzero_mask must have as many entries as data" \
                                                         " has modalities"
 
-        for c in range(len(data)):
-            scheme = self.normalization_scheme_per_modality[c]
+        for c, mod_id in enumerate(self.normalization_scheme_per_modality):
+            scheme = self.normalization_scheme_per_modality[mod_id]
             if scheme == "CT":
                 # clip to lb and ub from train data foreground and use foreground mn and sd from training data
                 assert self.intensityproperties is not None, "ERROR: if there is a CT then we need intensity properties"
-                mean_intensity = self.intensityproperties[c]['mean']
-                std_intensity = self.intensityproperties[c]['sd']
-                lower_bound = self.intensityproperties[c]['percentile_00_5']
-                upper_bound = self.intensityproperties[c]['percentile_99_5']
+                mean_intensity = self.intensityproperties[mod_id]['mean']
+                std_intensity = self.intensityproperties[mod_id]['sd']
+                lower_bound = self.intensityproperties[mod_id]['percentile_00_5']
+                upper_bound = self.intensityproperties[mod_id]['percentile_99_5']
                 data[c] = np.clip(data[c], lower_bound, upper_bound)
                 data[c] = (data[c] - mean_intensity) / std_intensity
-                if use_nonzero_mask[c]:
+                if use_nonzero_mask[mod_id]:
                     data[c][seg[-1] < 0] = 0
             elif scheme == "CT2":
                 # clip to lb and ub from train data foreground, use mn and sd form each case for normalization
                 assert self.intensityproperties is not None, "ERROR: if there is a CT then we need intensity properties"
-                lower_bound = self.intensityproperties[c]['percentile_00_5']
-                upper_bound = self.intensityproperties[c]['percentile_99_5']
+                lower_bound = self.intensityproperties[mod_id]['percentile_00_5']
+                upper_bound = self.intensityproperties[mod_id]['percentile_99_5']
                 mask = (data[c] > lower_bound) & (data[c] < upper_bound)
                 data[c] = np.clip(data[c], lower_bound, upper_bound)
                 mn = data[c][mask].mean()
                 sd = data[c][mask].std()
                 data[c] = (data[c] - mn) / sd
-                if use_nonzero_mask[c]:
+                if use_nonzero_mask[mod_id]:
                     data[c][seg[-1] < 0] = 0
             elif scheme == 'noNorm':
                 pass
             else:
-                if use_nonzero_mask[c]:
+                if use_nonzero_mask[mod_id]:
                     mask = seg[-1] >= 0
                 else:
                     mask = np.ones(seg.shape[1:], dtype=bool)
@@ -542,35 +542,35 @@ class Preprocessor3DBetterResampling(GenericPreprocessor):
         assert len(self.use_nonzero_mask) == len(data), "self.use_nonzero_mask must have as many entries as data" \
                                                         " has modalities"
 
-        for c in range(len(data)):
-            scheme = self.normalization_scheme_per_modality[c]
+        for c, mod_id in enumerate(self.normalization_scheme_per_modality):
+            scheme = self.normalization_scheme_per_modality[mod_id]
             if scheme == "CT":
                 # clip to lb and ub from train data foreground and use foreground mn and sd from training data
                 assert self.intensityproperties is not None, "ERROR: if there is a CT then we need intensity properties"
-                mean_intensity = self.intensityproperties[c]['mean']
-                std_intensity = self.intensityproperties[c]['sd']
-                lower_bound = self.intensityproperties[c]['percentile_00_5']
-                upper_bound = self.intensityproperties[c]['percentile_99_5']
+                mean_intensity = self.intensityproperties[mod_id]['mean']
+                std_intensity = self.intensityproperties[mod_id]['sd']
+                lower_bound = self.intensityproperties[mod_id]['percentile_00_5']
+                upper_bound = self.intensityproperties[mod_id]['percentile_99_5']
                 data[c] = np.clip(data[c], lower_bound, upper_bound)
                 data[c] = (data[c] - mean_intensity) / std_intensity
-                if use_nonzero_mask[c]:
+                if use_nonzero_mask[mod_id]:
                     data[c][seg[-1] < 0] = 0
             elif scheme == "CT2":
                 # clip to lb and ub from train data foreground, use mn and sd form each case for normalization
                 assert self.intensityproperties is not None, "ERROR: if there is a CT then we need intensity properties"
-                lower_bound = self.intensityproperties[c]['percentile_00_5']
-                upper_bound = self.intensityproperties[c]['percentile_99_5']
+                lower_bound = self.intensityproperties[mod_id]['percentile_00_5']
+                upper_bound = self.intensityproperties[mod_id]['percentile_99_5']
                 mask = (data[c] > lower_bound) & (data[c] < upper_bound)
                 data[c] = np.clip(data[c], lower_bound, upper_bound)
                 mn = data[c][mask].mean()
                 sd = data[c][mask].std()
                 data[c] = (data[c] - mn) / sd
-                if use_nonzero_mask[c]:
+                if use_nonzero_mask[mod_id]:
                     data[c][seg[-1] < 0] = 0
             elif scheme == 'noNorm':
                 pass
             else:
-                if use_nonzero_mask[c]:
+                if use_nonzero_mask[mod_id]:
                     mask = seg[-1] >= 0
                 else:
                     mask = np.ones(seg.shape[1:], dtype=bool)
@@ -644,35 +644,35 @@ class PreprocessorFor2D(GenericPreprocessor):
 
         print("normalization...")
 
-        for c in range(len(data)):
-            scheme = self.normalization_scheme_per_modality[c]
+        for c, mod_id in enumerate(self.normalization_scheme_per_modality):
+            scheme = self.normalization_scheme_per_modality[mod_id]
             if scheme == "CT":
                 # clip to lb and ub from train data foreground and use foreground mn and sd from training data
                 assert self.intensityproperties is not None, "ERROR: if there is a CT then we need intensity properties"
-                mean_intensity = self.intensityproperties[c]['mean']
-                std_intensity = self.intensityproperties[c]['sd']
-                lower_bound = self.intensityproperties[c]['percentile_00_5']
-                upper_bound = self.intensityproperties[c]['percentile_99_5']
+                mean_intensity = self.intensityproperties[mod_id]['mean']
+                std_intensity = self.intensityproperties[mod_id]['sd']
+                lower_bound = self.intensityproperties[mod_id]['percentile_00_5']
+                upper_bound = self.intensityproperties[mod_id]['percentile_99_5']
                 data[c] = np.clip(data[c], lower_bound, upper_bound)
                 data[c] = (data[c] - mean_intensity) / std_intensity
-                if use_nonzero_mask[c]:
+                if use_nonzero_mask[mod_id]:
                     data[c][seg[-1] < 0] = 0
             elif scheme == "CT2":
                 # clip to lb and ub from train data foreground, use mn and sd form each case for normalization
                 assert self.intensityproperties is not None, "ERROR: if there is a CT then we need intensity properties"
-                lower_bound = self.intensityproperties[c]['percentile_00_5']
-                upper_bound = self.intensityproperties[c]['percentile_99_5']
+                lower_bound = self.intensityproperties[mod_id]['percentile_00_5']
+                upper_bound = self.intensityproperties[mod_id]['percentile_99_5']
                 mask = (data[c] > lower_bound) & (data[c] < upper_bound)
                 data[c] = np.clip(data[c], lower_bound, upper_bound)
                 mn = data[c][mask].mean()
                 sd = data[c][mask].std()
                 data[c] = (data[c] - mn) / sd
-                if use_nonzero_mask[c]:
+                if use_nonzero_mask[mod_id]:
                     data[c][seg[-1] < 0] = 0
             elif scheme == 'noNorm':
                 pass
             else:
-                if use_nonzero_mask[c]:
+                if use_nonzero_mask[mod_id]:
                     mask = seg[-1] >= 0
                 else:
                     mask = np.ones(seg.shape[1:], dtype=bool)
@@ -732,35 +732,35 @@ class PreprocessorFor3D_LeaveOriginalZSpacing(GenericPreprocessor):
         assert len(self.use_nonzero_mask) == len(data), "self.use_nonzero_mask must have as many entries as data" \
                                                         " has modalities"
 
-        for c in range(len(data)):
-            scheme = self.normalization_scheme_per_modality[c]
+        for c, mod_id in enumerate(self.normalization_scheme_per_modality):
+            scheme = self.normalization_scheme_per_modality[mod_id]
             if scheme == "CT":
                 # clip to lb and ub from train data foreground and use foreground mn and sd from training data
                 assert self.intensityproperties is not None, "ERROR: if there is a CT then we need intensity properties"
-                mean_intensity = self.intensityproperties[c]['mean']
-                std_intensity = self.intensityproperties[c]['sd']
-                lower_bound = self.intensityproperties[c]['percentile_00_5']
-                upper_bound = self.intensityproperties[c]['percentile_99_5']
+                mean_intensity = self.intensityproperties[mod_id]['mean']
+                std_intensity = self.intensityproperties[mod_id]['sd']
+                lower_bound = self.intensityproperties[mod_id]['percentile_00_5']
+                upper_bound = self.intensityproperties[mod_id]['percentile_99_5']
                 data[c] = np.clip(data[c], lower_bound, upper_bound)
                 data[c] = (data[c] - mean_intensity) / std_intensity
-                if use_nonzero_mask[c]:
+                if use_nonzero_mask[mod_id]:
                     data[c][seg[-1] < 0] = 0
             elif scheme == "CT2":
                 # clip to lb and ub from train data foreground, use mn and sd form each case for normalization
                 assert self.intensityproperties is not None, "ERROR: if there is a CT then we need intensity properties"
-                lower_bound = self.intensityproperties[c]['percentile_00_5']
-                upper_bound = self.intensityproperties[c]['percentile_99_5']
+                lower_bound = self.intensityproperties[mod_id]['percentile_00_5']
+                upper_bound = self.intensityproperties[mod_id]['percentile_99_5']
                 mask = (data[c] > lower_bound) & (data[c] < upper_bound)
                 data[c] = np.clip(data[c], lower_bound, upper_bound)
                 mn = data[c][mask].mean()
                 sd = data[c][mask].std()
                 data[c] = (data[c] - mn) / sd
-                if use_nonzero_mask[c]:
+                if use_nonzero_mask[mod_id]:
                     data[c][seg[-1] < 0] = 0
             elif scheme == 'noNorm':
                 pass
             else:
-                if use_nonzero_mask[c]:
+                if use_nonzero_mask[mod_id]:
                     mask = seg[-1] >= 0
                 else:
                     mask = np.ones(seg.shape[1:], dtype=bool)
@@ -821,35 +821,35 @@ class PreprocessorFor3D_NoResampling(GenericPreprocessor):
         assert len(self.use_nonzero_mask) == len(data), "self.use_nonzero_mask must have as many entries as data" \
                                                         " has modalities"
 
-        for c in range(len(data)):
-            scheme = self.normalization_scheme_per_modality[c]
+        for c, mod_id in enumerate(self.normalization_scheme_per_modality):
+            scheme = self.normalization_scheme_per_modality[mod_id]
             if scheme == "CT":
                 # clip to lb and ub from train data foreground and use foreground mn and sd from training data
                 assert self.intensityproperties is not None, "ERROR: if there is a CT then we need intensity properties"
-                mean_intensity = self.intensityproperties[c]['mean']
-                std_intensity = self.intensityproperties[c]['sd']
-                lower_bound = self.intensityproperties[c]['percentile_00_5']
-                upper_bound = self.intensityproperties[c]['percentile_99_5']
+                mean_intensity = self.intensityproperties[mod_id]['mean']
+                std_intensity = self.intensityproperties[mod_id]['sd']
+                lower_bound = self.intensityproperties[mod_id]['percentile_00_5']
+                upper_bound = self.intensityproperties[mod_id]['percentile_99_5']
                 data[c] = np.clip(data[c], lower_bound, upper_bound)
                 data[c] = (data[c] - mean_intensity) / std_intensity
-                if use_nonzero_mask[c]:
+                if use_nonzero_mask[mod_id]:
                     data[c][seg[-1] < 0] = 0
             elif scheme == "CT2":
                 # clip to lb and ub from train data foreground, use mn and sd form each case for normalization
                 assert self.intensityproperties is not None, "ERROR: if there is a CT then we need intensity properties"
-                lower_bound = self.intensityproperties[c]['percentile_00_5']
-                upper_bound = self.intensityproperties[c]['percentile_99_5']
+                lower_bound = self.intensityproperties[mod_id]['percentile_00_5']
+                upper_bound = self.intensityproperties[mod_id]['percentile_99_5']
                 mask = (data[c] > lower_bound) & (data[c] < upper_bound)
                 data[c] = np.clip(data[c], lower_bound, upper_bound)
                 mn = data[c][mask].mean()
                 sd = data[c][mask].std()
                 data[c] = (data[c] - mn) / sd
-                if use_nonzero_mask[c]:
+                if use_nonzero_mask[mod_id]:
                     data[c][seg[-1] < 0] = 0
             elif scheme == 'noNorm':
                 pass
             else:
-                if use_nonzero_mask[c]:
+                if use_nonzero_mask[mod_id]:
                     mask = seg[-1] >= 0
                 else:
                     mask = np.ones(seg.shape[1:], dtype=bool)

--- a/nnunet/preprocessing/sanity_checks.py
+++ b/nnunet/preprocessing/sanity_checks.py
@@ -104,6 +104,7 @@ def verify_dataset_integrity(folder):
     dataset = load_json(join(folder, "dataset.json"))
     training_cases = dataset['training']
     num_modalities = len(dataset['modality'].keys())
+    modalities = dataset['modality']
     test_cases = dataset['test']
     expected_train_identifiers = [i['image'].split("/")[-1][:-7] for i in training_cases]
     expected_test_identifiers = [i.split("/")[-1][:-7] for i in test_cases]
@@ -117,7 +118,8 @@ def verify_dataset_integrity(folder):
     has_nan = False
 
     # check all cases
-    if len(expected_train_identifiers) != len(np.unique(expected_train_identifiers)): raise RuntimeError("found duplicate training cases in dataset.json")
+    if len(expected_train_identifiers) != len(np.unique(expected_train_identifiers)):
+        raise RuntimeError("found duplicate training cases in dataset.json")
 
     print("Verifying training set")
     for c in expected_train_identifiers:
@@ -125,7 +127,7 @@ def verify_dataset_integrity(folder):
         # check if all files are present
         expected_label_file = join(folder, "labelsTr", c + ".nii.gz")
         label_files.append(expected_label_file)
-        expected_image_files = [join(folder, "imagesTr", c + "_%04.0d.nii.gz" % i) for i in range(num_modalities)]
+        expected_image_files = [join(folder, "imagesTr", f"{c}_{int(i):04d}.nii.gz") for i in modalities]
         assert isfile(expected_label_file), "could not find label file for case %s. Expected file: \n%s" % (
             c, expected_label_file)
         assert all([isfile(i) for i in
@@ -199,7 +201,7 @@ def verify_dataset_integrity(folder):
 
         for c in expected_test_identifiers:
             # check if all files are present
-            expected_image_files = [join(folder, "imagesTs", c + "_%04.0d.nii.gz" % i) for i in range(num_modalities)]
+            expected_image_files = [join(folder, "imagesTs", f"{c}_{int(i):04d}.nii.gz") for i in modalities]
             assert all([isfile(i) for i in
                         expected_image_files]), "some image files are missing for case %s. Expected files:\n %s" % (
                 c, expected_image_files)


### PR DESCRIPTION
In my projects working with DIXON-MRI, I usually encounter 4 or 6 different modalities selecting different combinations for different tasks. Already trained models potentially need to adapt their plans.pkl file.

Changes:
Read dictionary items from modalities instead of range()-ing.
Allow using the same image dataset (e.g. DIXON MRI) for different tasks with
different focus and modality requirements.