### PR TITLE
NameError: No module named 'List'

### DIFF
--- a/nnunet/training/network_training/nnUNetTrainer.py
+++ b/nnunet/training/network_training/nnUNetTrainer.py
@@ -18,6 +18,7 @@ from collections import OrderedDict
 from multiprocessing import Pool
 from time import sleep
 from typing import Tuple
+from typing import List
 
 import matplotlib
 import numpy as np


### PR DESCRIPTION
Latest nnUNet Trainer throws NameError: No module named 'List'

Running in Google Colab, python 3.7.11

Fixed by adding
`from typing import List`