### PR TITLE
Fix typos and remove invalid escape sequences

### DIFF
--- a/nnunet/inference/predict.py
+++ b/nnunet/inference/predict.py
@@ -60,9 +60,9 @@ def preprocess_save_to_queue(preprocess_fn, q, list_of_lists, output_files, segs
                 seg_reshaped = resize_segmentation(seg_prev, d.shape[1:], order=1)
                 seg_reshaped = to_one_hot(seg_reshaped, classes)
                 d = np.vstack((d, seg_reshaped)).astype(np.float32)
-            """There is a problem with python process communication that prevents us from communicating obejcts 
+            """There is a problem with python process communication that prevents us from communicating objects 
             larger than 2 GB between processes (basically when the length of the pickle string that will be sent is 
-            communicated by the multiprocessing.Pipe object then the placeholder (\%i I think) does not allow for long 
+            communicated by the multiprocessing.Pipe object then the placeholder (I think) does not allow for long 
             enough strings (lol). This could be fixed by changing i to l (for long) but that would require manually 
             patching system python code. We circumvent that problem here by saving softmax_pred to a npy file that will 
             then be read (and finally deleted) by the Process. save_segmentation_nifti_from_softmax can take either 
@@ -243,9 +243,9 @@ def predict_cases(model, list_of_lists, output_filenames, folds, save_npz, num_t
         else:
             region_class_order = None
 
-        """There is a problem with python process communication that prevents us from communicating obejcts 
+        """There is a problem with python process communication that prevents us from communicating objects 
         larger than 2 GB between processes (basically when the length of the pickle string that will be sent is 
-        communicated by the multiprocessing.Pipe object then the placeholder (\%i I think) does not allow for long 
+        communicated by the multiprocessing.Pipe object then the placeholder (I think) does not allow for long 
         enough strings (lol). This could be fixed by changing i to l (for long) but that would require manually 
         patching system python code. We circumvent that problem here by saving softmax_pred to a npy file that will 
         then be read (and finally deleted) by the Process. save_segmentation_nifti_from_softmax can take either 

--- a/nnunet/inference/segmentation_export.py
+++ b/nnunet/inference/segmentation_export.py
@@ -32,16 +32,16 @@ def save_segmentation_nifti_from_softmax(segmentation_softmax: Union[str, np.nda
                                          non_postprocessed_fname: str = None, force_separate_z: bool = None,
                                          interpolation_order_z: int = 0, verbose: bool = True):
     """
-    This is a utility for writing segmentations to nifto and npz. It requires the data to have been preprocessed by
+    This is a utility for writing segmentations to nifty and npz. It requires the data to have been preprocessed by
     GenericPreprocessor because it depends on the property dictionary output (dct) to know the geometry of the original
     data. segmentation_softmax does not have to have the same size in pixels as the original data, it will be
     resampled to match that. This is generally useful because the spacings our networks operate on are most of the time
     not the native spacings of the image data.
     If seg_postprogess_fn is not None then seg_postprogess_fnseg_postprogess_fn(segmentation, *seg_postprocess_args)
-    will be called before nifto export
-    There is a problem with python process communication that prevents us from communicating obejcts
+    will be called before nifty export
+    There is a problem with python process communication that prevents us from communicating objects
     larger than 2 GB between processes (basically when the length of the pickle string that will be sent is
-    communicated by the multiprocessing.Pipe object then the placeholder (\%i I think) does not allow for long
+    communicated by the multiprocessing.Pipe object then the placeholder (I think) does not allow for long
     enough strings (lol). This could be fixed by changing i to l (for long) but that would require manually
     patching system python code.) We circumvent that problem here by saving softmax_pred to a npy file that will
     then be read (and finally deleted) by the Process. save_segmentation_nifti_from_softmax can take either

--- a/nnunet/training/data_augmentation/pyramid_augmentations.py
+++ b/nnunet/training/data_augmentation/pyramid_augmentations.py
@@ -24,7 +24,7 @@ class RemoveRandomConnectedComponentFromOneHotEncodingTransform(AbstractTransfor
     def __init__(self, channel_idx, key="data", p_per_sample=0.2, fill_with_other_class_p=0.25,
                  dont_do_if_covers_more_than_X_percent=0.25, p_per_label=1):
         """
-        :param dont_do_if_covers_more_than_X_percent: dont_do_if_covers_more_than_X_percent=0.25 is 25\%!
+        :param dont_do_if_covers_more_than_X_percent: dont_do_if_covers_more_than_X_percent=0.25 is 25%!
         :param channel_idx: can be list or int
         :param key:
         """

--- a/nnunet/training/network_training/nnUNetTrainer.py
+++ b/nnunet/training/network_training/nnUNetTrainer.py
@@ -608,9 +608,9 @@ class nnUNetTrainer(NetworkTrainer):
                 else:
                     softmax_fname = None
 
-                """There is a problem with python process communication that prevents us from communicating obejcts
+                """There is a problem with python process communication that prevents us from communicating objects
                 larger than 2 GB between processes (basically when the length of the pickle string that will be sent is
-                communicated by the multiprocessing.Pipe object then the placeholder (\%i I think) does not allow for long
+                communicated by the multiprocessing.Pipe object then the placeholder (I think) does not allow for long
                 enough strings (lol). This could be fixed by changing i to l (for long) but that would require manually
                 patching system python code. We circumvent that problem here by saving softmax_pred to a npy file that will
                 then be read (and finally deleted) by the Process. save_segmentation_nifti_from_softmax can take either


### PR DESCRIPTION
Using nnUNet and Python3.8 I got some deprecation warnings due to the use of `\%` in some docstrings:

```
nnunet/inference/predict.py:65
  /codebase/nnunet/inference/predict.py:65: DeprecationWarning: invalid escape sequence \%
    """There is a problem with python process communication that prevents us from communicating obejcts

nnunet/inference/predict.py:248
  /codebase/nnunet/inference/predict.py:248: DeprecationWarning: invalid escape sequence \%
    """There is a problem with python process communication that prevents us from communicating obejcts

nnunet/inference/segmentation_export.py:36
  /codebase/nnunet/inference/segmentation_export.py:36: DeprecationWarning: invalid escape sequence \%
    """

nnunet/training/network_training/nnUNetTrainer.py:609
  /codebase/nnunet/training/network_training/nnUNetTrainer.py:609: DeprecationWarning: invalid escape sequence \%
    """There is a problem with python process communication that prevents us from communicating obejcts

nnunet/training/data_augmentation/pyramid_augmentations.py:26
  /codebase/nnunet/training/data_augmentation/pyramid_augmentations.py:26: DeprecationWarning: invalid escape sequence \%
    """
```

This PR removes the invalid sequences and fixes some typos in the docstrings.