### PR TITLE
fix misjudgement of labels consecutity when the number of labels over 10

### DIFF
--- a/nnunet/preprocessing/sanity_checks.py
+++ b/nnunet/preprocessing/sanity_checks.py
@@ -166,7 +166,7 @@ def verify_dataset_integrity(folder):
 
     # verify that only properly declared values are present in the labels
     print("Verifying label values")
-    expected_labels = list(int(i) for i in dataset['labels'].keys())
+    expected_labels = sorted(list(int(i) for i in dataset['labels'].keys()))
 
     # check if labels are in consecutive order
     assert expected_labels[0] == 0, 'The first label must be 0 and maps to the background'


### PR DESCRIPTION
When the number of labels is over 10,  it comes up with
AssertionError: Labels must be in consecutive order (0, 1, 2, ...). The labels [10  2] do not satisfy this restriction
sorted function can fix the problem