### PR TITLE
Added timeout on request.get() for ensuring that if a recipient serve…

### DIFF
--- a/nnunet/inference/pretrained_models/download_pretrained_model.py
+++ b/nnunet/inference/pretrained_models/download_pretrained_model.py
@@ -294,7 +294,8 @@ def download_and_install_from_url(url):
 def download_file(url: str, local_filename: str, chunk_size: Optional[int] = 8192 * 16) -> str:
     # borrowed from https://stackoverflow.com/questions/16694907/download-large-file-in-python-with-requests
     # NOTE the stream=True parameter below
-    with requests.get(url, stream=True) as r:
+    # OpenRefactory Warning: The 'requests.get' method does not use any 'timeout' threshold which may cause program to hang indefinitely.
+    with requests.get(url, stream=True, timeout=100) as r:
         r.raise_for_status()
         # with open(local_filename, 'wb') as f:
         #     for chunk in r.iter_content(chunk_size=chunk_size):


### PR DESCRIPTION
We have detected this issue in the `master` branch of `nnUNet` project on the version with commit hash fd58e2. This is an instance of an api usage issue.

**Fixes for api useage issues:**
In file: `download_pretrained_model.py`, method `download_file` a request is made without a timeout parameter. If the recipient server is unavailable to service the request, [application making the request may stall indefinitely. ](https://docs.python-requests.org/en/master/user/advanced/#timeouts)our intelligent code repair system **iCR** suggested that a timeout value should be specified.

This issue was detected by our **OpenRefactory's Intelligent Code Repair (iCR)**. We are running **iCR** on libraries in the `PyPI` repository to identify issues and fix them. You will get more info at: [pypi.openrefactory.com](https://pypi.openrefactory.com/)