### PR TITLE
In DDP mode, Fix the error of deleting the latest model at the end of training 

### DIFF
--- a/nnunet/training/network_training/network_trainer.py
+++ b/nnunet/training/network_training/network_trainer.py
@@ -496,6 +496,10 @@ class NetworkTrainer(object):
 
         if self.save_final_checkpoint: self.save_checkpoint(join(self.output_folder, "model_final_checkpoint.model"))
         # now we can delete latest as it will be identical with final
+        
+        self.delete_latest_model()
+        
+    def delete_latest_model(self):
         if isfile(join(self.output_folder, "model_latest.model")):
             os.remove(join(self.output_folder, "model_latest.model"))
         if isfile(join(self.output_folder, "model_latest.model.pkl")):

--- a/nnunet/training/network_training/nnUNetTrainerV2_DDP.py
+++ b/nnunet/training/network_training/nnUNetTrainerV2_DDP.py
@@ -122,6 +122,10 @@ class nnUNetTrainerV2_DDP(nnUNetTrainerV2):
     def plot_progress(self):
         if self.local_rank == 0:
             super().plot_progress()
+    
+    def delete_latest_model(self):
+        if self.local_rank == 0:
+            super().delete_latest_model()
 
     def print_to_log_file(self, *args, also_print_to_console=True):
         if self.local_rank == 0:


### PR DESCRIPTION
In DDP mode, at the end of training, different processes will delete the latest model, causing some processes to enter the if statement, but when "os.remove" is executed, other processes have deleted the file, so an error "FileNotFoundError: [Errno 2 ] No such file or directory" will be reported.

Refer to the methods "save_checkpoint", "plot_progress", write the delete model as a function, under DDP, rewrite this function, just add "if self.local_rank == 0"