### PR TITLE
Fix attempting to load non-existent checkpoint

### DIFF
--- a/nnunetv2/run/run_training.py
+++ b/nnunetv2/run/run_training.py
@@ -82,6 +82,7 @@ def maybe_load_checkpoint(nnunet_trainer: nnUNetTrainer, continue_training: bool
         if not isfile(expected_checkpoint_file):
             print(f"WARNING: Cannot continue training because there seems to be no checkpoint available to "
                                f"continue from. Starting a new training...")
+            expected_checkpoint_file = None
     elif validation_only:
         expected_checkpoint_file = join(nnunet_trainer.output_folder, 'checkpoint_final.pth')
         if not isfile(expected_checkpoint_file):


### PR DESCRIPTION
Based on "Starting a new training..." I assume the intent is for this not to be a fatal error (which is different from nnUNet v1). But since `expected_checkpoint_file` isn't reset it still crashes attempting to read the non-existent checkpoint_best.pth file.