### PR TITLE
escape re pattern; fix typo in conversion script

### DIFF
--- a/nnunetv2/dataset_conversion/Dataset120_RoadSegmentation.py
+++ b/nnunetv2/dataset_conversion/Dataset120_RoadSegmentation.py
@@ -84,4 +84,4 @@ if __name__ == "__main__":
         _ = [i.get() for i in r]
 
     generate_dataset_json(join(nnUNet_raw, dataset_name), {0: 'R', 1: 'G', 2: 'B'}, {'background': 0, 'road': 1},
-                          num_train, '.png', dataset_name)
+                          num_train, '.png', dataset_name=dataset_name)

--- a/nnunetv2/experiment_planning/verify_dataset_integrity.py
+++ b/nnunetv2/experiment_planning/verify_dataset_integrity.py
@@ -48,7 +48,7 @@ def check_cases(base_folder: str, case_identifier: str, expected_num_channels: i
     rw = readerclass()
     ret = True
     file_seg = join(base_folder, 'labelsTr', case_identifier + file_ending)
-    pattern = re.compile(case_identifier + "_\d\d\d\d" + file_ending)
+    pattern = re.compile(re.escape(case_identifier) + r"_\d\d\d\d" + re.escape(file_ending))
     files_image = [join(base_folder, 'imagesTr', i) for i in subfiles(join(base_folder, 'imagesTr'),
                                                                       prefix=case_identifier,
                                                                       suffix=file_ending,

--- a/nnunetv2/utilities/utils.py
+++ b/nnunetv2/utilities/utils.py
@@ -38,6 +38,6 @@ def create_lists_from_splitted_dataset_folder(folder: str, file_ending: str, ide
     files = subfiles(folder, suffix=file_ending, join=False, sort=True)
     list_of_lists = []
     for f in identifiers:
-        p = re.compile(f + "_\d\d\d\d" + file_ending)
+        p = re.compile(re.escape(f) + r"_\d\d\d\d" + re.escape(file_ending))
         list_of_lists.append([join(folder, i) for i in files if p.fullmatch(i)])
     return list_of_lists


### PR DESCRIPTION
I escaped the regular expression pattern to make it more robust (without escape, e.g., the `.` character in `.png` will match any character, and the match will also fail if the case identifier contains any preserved special character of the `re` library). 

Additionally, I fixed a typo in `nnunetv2/dataset_conversion/Dataset120_RoadSegmentation.py` that mismatches the positional argument.