### PR TITLE
Fixed the bug that command parsing -f is str

### DIFF
--- a/nnunetv2/model_sharing/entry_points.py
+++ b/nnunetv2/model_sharing/entry_points.py
@@ -49,7 +49,7 @@ def export_pretrained_model_entry():
                         help="List of configuration names")
     parser.add_argument('-tr', required=False, type=str, default='nnUNetTrainer', help='Trainer class')
     parser.add_argument('-p', required=False, type=str, default='nnUNetPlans', help='plans identifier')
-    parser.add_argument('-f', required=False, nargs='+', type=str, default=(0, 1, 2, 3, 4), help='list of fold ids')
+    parser.add_argument('-f', required=False, nargs='+', type=int, default=(0, 1, 2, 3, 4), help='list of fold ids')
     parser.add_argument('-chk', required=False, nargs='+', type=str, default=('checkpoint_final.pth', ),
                         help='Lis tof checkpoint names to export. Default: checkpoint_final.pth')
     parser.add_argument('--not_strict', action='store_false', default=False, required=False, help='Set this to allow missing folds and/or configurations')


### PR DESCRIPTION
In the command nnUNetv2_export_model_to_zip -f 2, it will parse 2 as str, making it unrecognizable. 

> expected_fold_folder = ["fold_%d" % i if i != 'all' else 'fold_all' for i in folds] 
TypeError: %d format: a number is required, not str