### PR TITLE
Default num processes fix

### DIFF
--- a/nnunetv2/experiment_planning/plan_and_preprocess_entrypoints.py
+++ b/nnunetv2/experiment_planning/plan_and_preprocess_entrypoints.py
@@ -187,12 +187,8 @@ def plan_and_preprocess_entry():
 
     # manage default np
     if args.np is None:
-        default_np = {
-            '2d': 4,
-            '3d_lowres': 8,
-            '3d_fullres': 4
-        }
         np = {default_np[c] if c in default_np.keys() else 4 for c in args.c}
+        default_np = {"2d": 8, "3d_lowres": 8, "3d_fullres": 4}
     else:
         np = args.np
     # preprocessing

--- a/nnunetv2/experiment_planning/plan_and_preprocess_entrypoints.py
+++ b/nnunetv2/experiment_planning/plan_and_preprocess_entrypoints.py
@@ -187,8 +187,8 @@ def plan_and_preprocess_entry():
 
     # manage default np
     if args.np is None:
-        np = {default_np[c] if c in default_np.keys() else 4 for c in args.c}
         default_np = {"2d": 8, "3d_lowres": 8, "3d_fullres": 4}
+        np = [default_np[c] if c in default_np.keys() else 4 for c in args.c]
     else:
         np = args.np
     # preprocessing

--- a/nnunetv2/experiment_planning/plan_and_preprocess_entrypoints.py
+++ b/nnunetv2/experiment_planning/plan_and_preprocess_entrypoints.py
@@ -187,7 +187,7 @@ def plan_and_preprocess_entry():
 
     # manage default np
     if args.np is None:
-        default_np = {"2d": 8, "3d_lowres": 8, "3d_fullres": 4}
+        default_np = {"2d": 8, "3d_fullres": 4, "3d_lowres": 8}
         np = [default_np[c] if c in default_np.keys() else 4 for c in args.c]
     else:
         np = args.np


### PR DESCRIPTION
A few small fixes:

1. The documentation for the default num processes for "2d" configuration species the num processes as 8, but was defaulting to 4.
2. Make the order of default num processes match the default order of the '-c' option (2d, 3d_fullres, 3d_lowres).
3. Since a set was used to store `np`, it would not allow duplicate num procceses. If we had (8, 4, 8), this would reduce to (8, 4), and there would subsequently be an [error thrown due to mismatching number of processes and number of configurations.](https://github.com/MIC-DKFZ/nnUNet/blob/master/nnunetv2/experiment_planning/plan_and_preprocess_api.py#L95)