### PR TITLE
Avoid index error when `spacings_of_axes` limited

### DIFF
--- a/nnunetv2/experiment_planning/experiment_planners/network_topology.py
+++ b/nnunetv2/experiment_planning/experiment_planners/network_topology.py
@@ -75,11 +75,7 @@ def get_pool_and_conv_props(spacing, patch_size, min_feature_map_size, max_numpo
         # now we need to find kernel sizes
         # kernel sizes are initialized to 1. They are successively set to 3 when their associated axis becomes within
         # factor 2 of min_spacing. Once they are 3 they remain 3
-        for d in range(dim):
-            # If we are at a dimension index that is greater than the length of spacings_of_axes, we should break to
-            # avoid an index out of range error.
-            if d == len(spacings_of_axes):
-                break
+        for d in range(min(dim, len(spacings_of_axes))):
             if kernel_size[d] == 3:
                 continue
             else:

--- a/nnunetv2/experiment_planning/experiment_planners/network_topology.py
+++ b/nnunetv2/experiment_planning/experiment_planners/network_topology.py
@@ -76,6 +76,10 @@ def get_pool_and_conv_props(spacing, patch_size, min_feature_map_size, max_numpo
         # kernel sizes are initialized to 1. They are successively set to 3 when their associated axis becomes within
         # factor 2 of min_spacing. Once they are 3 they remain 3
         for d in range(dim):
+            # If we are at a dimension index that is greater than the length of spacings_of_axes, we should break to
+            # avoid an index out of range error.
+            if d == len(spacings_of_axes):
+                break
             if kernel_size[d] == 3:
                 continue
             else:


### PR DESCRIPTION
`spacing_of_axes` [is defined in reference to `valid_axes_for_pool`](https://github.com/MIC-DKFZ/nnUNet/blob/master/nnunetv2/experiment_planning/experiment_planners/network_topology.py#L58). Since it is [possible for `valid_axes_for_pool` to be of a smaller length than `dims`](https://github.com/MIC-DKFZ/nnUNet/blob/master/nnunetv2/experiment_planning/experiment_planners/network_topology.py#L54), we can run into an index out of range error when[ attempting to access a dimensionality index](https://github.com/MIC-DKFZ/nnUNet/blob/master/nnunetv2/experiment_planning/experiment_planners/network_topology.py#L82) that does not exist within `spacing_of_axes`.

This (small) change adds a check to see if we are out of bounds for `spaces_of_axes` and if so break.