### PR TITLE
There are some ambiguous descriptions in region_based_training.md

### DIFF
--- a/documentation/region_based_training.md
+++ b/documentation/region_based_training.md
@@ -54,13 +54,14 @@ For region-based training, the labels need to be changed to the following:
     "tumor_core": [2, 3],
     "enhancing_tumor": 3  # or [3]
 },
-"regions_class_order": [1, 2, 3],
+"regions_class_order": [2, 1, 3],
 ...
 ```
 This corresponds to the bottom row in the figure above. Note how an additional entry in the dataset.json is 
 required: `regions_class_order`. This tells nnU-Net how to convert the region representations back to an integer map. 
-It essentially just tells nnU-Net what labels to place for which region in what order. Concretely, for the example 
-given here, nnU-Net will place the label 1 for the 'whole_tumor' region, then place the label 2 where the "tumor_core" 
+It essentially just tells nnU-Net what labels to place for which region in what order, to be precise, the number in 
+the list represents the output labels of the regions respectively. Concretely, for the example given here, nnU-Net 
+will firstly place the label 2 for the 'whole_tumor' region, then place the label 1 where the "tumor_core" 
 is and finally place the label 3 in the 'enhancing_tumor' area. With each step, part of the previously set pixels 
 will be overwritten with the new label! So when setting your `regions_class_order`, place encompassing regions 
 (like whole tumor etc) first, followed by substructures.


### PR DESCRIPTION
The numbers in the 'region_class_order' are not the order in which the labels are written, but which number of labels the regions correspond to!
It's easy to misunderstand when seeing the name 'region_class_order' for the first time, I just thought that it means the order how will the labels be written, on the other hand, I thought the order of the numbers in the list will determine the representations of output labels, which means: '1' is the **first** number in the list, so it corresponds to the **label 1**. The given example is still right even if I understand it like this, and this can result in outputs different from the ground truth. So it's essential to change the example a little. 
I have used 3 days to find out why label 1 and label 2 are exchanged in my experiments because the key code(label_handling.py, line 171) is in starmap_async(), and the breakpoint debugging will jump it. T T