### PR TITLE
Fix windows env variables instructions

### DIFF
--- a/documentation/set_environment_variables.md
+++ b/documentation/set_environment_variables.md
@@ -53,16 +53,16 @@ Just execute the following before you run nnU-Net:
 
 (powershell)
 ```powershell
-$Env:nnUNet_raw = "/media/fabian/nnUNet_raw"
-$Env:nnUNet_preprocessed = "/media/fabian/nnUNet_preprocessed"
-$Env:nnUNet_results = "/media/fabian/nnUNet_results"
+$Env:nnUNet_raw = "C:/Users/fabian/nnUNet_raw"
+$Env:nnUNet_preprocessed = "C:/Users/fabian/nnUNet_preprocessed"
+$Env:nnUNet_results = "C:/Users/fabian/fabian/nnUNet_results"
 ```
 
 (command prompt)
 ```commandline
-set nnUNet_raw="/media/fabian/nnUNet_raw"
-set nnUNet_preprocessed="/media/fabian/nnUNet_preprocessed"
-set nnUNet_results="/media/fabian/nnUNet_results"
+set nnUNet_raw=C:/Users/fabian/nnUNet_raw
+set nnUNet_preprocessed=C:/Users/fabian/nnUNet_preprocessed
+set nnUNet_results=C:/Users/fabian/fabian/nnUNet_results
 ```
 
 (of course you need to adapt the paths to the actual folders you intend to use).

--- a/documentation/set_environment_variables.md
+++ b/documentation/set_environment_variables.md
@@ -16,7 +16,7 @@ export nnUNet_preprocessed="/media/fabian/nnUNet_preprocessed"
 export nnUNet_results="/media/fabian/nnUNet_results"
 ```
 
-(of course you need to adapt the paths to the actual folders you intend to use).
+(Of course you need to adapt the paths to the actual folders you intend to use).
 If you are using a different shell, such as zsh, you will need to find the correct script for it. For zsh this is `.zshrc`.
 
 ## Temporary
@@ -26,7 +26,7 @@ export nnUNet_raw="/media/fabian/nnUNet_raw"
 export nnUNet_preprocessed="/media/fabian/nnUNet_preprocessed"
 export nnUNet_results="/media/fabian/nnUNet_results"
 ```
-(of course you need to adapt the paths to the actual folders you intend to use).
+(Of course you need to adapt the paths to the actual folders you intend to use).
 
 Important: These variables will be deleted if you close your terminal! They will also only apply to the current 
 terminal window and DO NOT transfer to other terminals!
@@ -51,21 +51,21 @@ Or read about setx (command prompt).
 ## Temporary
 Just execute the following before you run nnU-Net:
 
-(powershell)
-```powershell
+(PowerShell)
+```PowerShell
 $Env:nnUNet_raw = "C:/Users/fabian/nnUNet_raw"
 $Env:nnUNet_preprocessed = "C:/Users/fabian/nnUNet_preprocessed"
 $Env:nnUNet_results = "C:/Users/fabian/fabian/nnUNet_results"
 ```
 
-(command prompt)
-```commandline
+(Command Prompt)
+```Command Prompt
 set nnUNet_raw=C:/Users/fabian/nnUNet_raw
 set nnUNet_preprocessed=C:/Users/fabian/nnUNet_preprocessed
 set nnUNet_results=C:/Users/fabian/fabian/nnUNet_results
 ```
 
-(of course you need to adapt the paths to the actual folders you intend to use).
+(Of course you need to adapt the paths to the actual folders you intend to use).
 
 Important: These variables will be deleted if you close your session! They will also only apply to the current 
 window and DO NOT transfer to other sessions!
@@ -73,6 +73,6 @@ window and DO NOT transfer to other sessions!
 ## Verify that environment parameters are set
 Printing in Windows works differently depending on the environment you are in:
 
-powershell: `echo $Env:[variable_name]`
+PowerShell: `echo $Env:[variable_name]`
 
-command prompt: `echo %[variable_name]%`
+Command Prompt: `echo %[variable_name]%`

--- a/documentation/set_environment_variables.md
+++ b/documentation/set_environment_variables.md
@@ -55,7 +55,7 @@ Just execute the following before you run nnU-Net:
 ```PowerShell
 $Env:nnUNet_raw = "C:/Users/fabian/nnUNet_raw"
 $Env:nnUNet_preprocessed = "C:/Users/fabian/nnUNet_preprocessed"
-$Env:nnUNet_results = "C:/Users/fabian/fabian/nnUNet_results"
+$Env:nnUNet_results = "C:/Users/fabian/nnUNet_results"
 ```
 
 (Command Prompt)


### PR DESCRIPTION
While Powershell is smart enough to remove the quotation marks surrounding a directory, the quotes will be included in the path when using the Command Prompt.

This will cause a failure to find the dataset.

My branch removes the quotation marks in the instructions for the Command Prompt and also makes a couple cosmetic changes.

Here's an example on Windows 10 through Anaconda Prompt:

Initialize the environment and show that the environmental variables are unset
```
(base) C:\>conda activate nnunet

(nnunet) C:\>echo %nnUNet_raw%
%nnUNet_raw%

(nnunet) C:\>echo %nnUNet_preprocessed%
%nnUNet_preprocessed%

(nnunet) C:\>echo %nnUNet_results%
%nnUNet_results%
```

Unset variables leads to an error (as expected)

```
(nnunet) C:\>nnUNetv2_plan_and_preprocess -d 300
nnUNet_raw is not defined and nnU-Net can only be used on data for which preprocessed files are already present on your system. nnU-Net cannot be used for experiment planning and preprocessing like this. If this is not intended, please read documentation/setting_up_paths.md for information on how to set this up properly.
nnUNet_preprocessed is not defined and nnU-Net can not be used for preprocessing or training. If this is not intended, please read documentation/setting_up_paths.md for information on how to set this up.
nnUNet_results is not defined and nnU-Net cannot be used for training or inference. If this is not intended behavior, please read documentation/setting_up_paths.md for information on how to set this up.
Fingerprint extraction...
Traceback (most recent call last):
  File "C:\ProgramData\Anaconda3\envs\nnunet\Scripts\nnUNetv2_plan_and_preprocess-script.py", line 33, in <module>
    sys.exit(load_entry_point('nnunetv2', 'console_scripts', 'nnUNetv2_plan_and_preprocess')())
  File "c:\github\nnunet\nnunetv2\experiment_planning\plan_and_preprocess_entrypoints.py", line 182, in plan_and_preprocess_entry
    extract_fingerprints(args.d, args.fpe, args.npfp, args.verify_dataset_integrity, args.clean, args.verbose)
  File "c:\github\nnunet\nnunetv2\experiment_planning\plan_and_preprocess_api.py", line 46, in extract_fingerprints
    extract_fingerprint_dataset(d, fingerprint_extractor_class, num_processes, check_dataset_integrity, clean,
  File "c:\github\nnunet\nnunetv2\experiment_planning\plan_and_preprocess_api.py", line 25, in extract_fingerprint_dataset
    dataset_name = convert_id_to_dataset_name(dataset_id)
  File "c:\github\nnunet\nnunetv2\utilities\dataset_name_id_conversion.py", line 48, in convert_id_to_dataset_name
    raise RuntimeError(f"Could not find a dataset with the ID {dataset_id}. Make sure the requested dataset ID "
RuntimeError: Could not find a dataset with the ID 300. Make sure the requested dataset ID exists and that nnU-Net knows where raw and preprocessed data are located (see Documentation - Installation). Here are your currently defined folders:
nnUNet_preprocessed=None
nnUNet_results=None
nnUNet_raw=None
If something is not right, adapt your environment variables.
```

Trying to set them as currently written in the documentation also leads to an error
```
(nnunet) C:\>set nnUNet_raw="C:/data/Will/nnUNet/nnUNet_raw"

(nnunet) C:\>set nnUNet_preprocessed="C:/data/Will/nnUNet/nnUNet_preprocessed"

(nnunet) C:\>set nnUNet_results="C:/data/Will/nnUNet/nnUNet_results"

(nnunet) C:\>nnUNetv2_plan_and_preprocess -d 300
Fingerprint extraction...
Traceback (most recent call last):
  File "C:\ProgramData\Anaconda3\envs\nnunet\Scripts\nnUNetv2_plan_and_preprocess-script.py", line 33, in <module>
    sys.exit(load_entry_point('nnunetv2', 'console_scripts', 'nnUNetv2_plan_and_preprocess')())
  File "c:\github\nnunet\nnunetv2\experiment_planning\plan_and_preprocess_entrypoints.py", line 182, in plan_and_preprocess_entry
    extract_fingerprints(args.d, args.fpe, args.npfp, args.verify_dataset_integrity, args.clean, args.verbose)
  File "c:\github\nnunet\nnunetv2\experiment_planning\plan_and_preprocess_api.py", line 46, in extract_fingerprints
    extract_fingerprint_dataset(d, fingerprint_extractor_class, num_processes, check_dataset_integrity, clean,
  File "c:\github\nnunet\nnunetv2\experiment_planning\plan_and_preprocess_api.py", line 25, in extract_fingerprint_dataset
    dataset_name = convert_id_to_dataset_name(dataset_id)
  File "c:\github\nnunet\nnunetv2\utilities\dataset_name_id_conversion.py", line 48, in convert_id_to_dataset_name
    raise RuntimeError(f"Could not find a dataset with the ID {dataset_id}. Make sure the requested dataset ID "
RuntimeError: Could not find a dataset with the ID 300. Make sure the requested dataset ID exists and that nnU-Net knows where raw and preprocessed data are located (see Documentation - Installation). Here are your currently defined folders:
nnUNet_preprocessed="C:/data/Will/nnUNet/nnUNet_preprocessed"
nnUNet_results="C:/data/Will/nnUNet/nnUNet_results"
nnUNet_raw="C:/data/Will/nnUNet/nnUNet_raw"
If something is not right, adapt your environment variables.
```

Setting the environment variables without quotation marks in the Command Prompt is the way to go
```
(nnunet) C:\>set nnUNet_raw=C:/data/Will/nnUNet/nnUNet_raw

(nnunet) C:\>set nnUNet_results=C:/data/Will/nnUNet/nnUNet_results

(nnunet) C:\>set nnUNet_preprocessed=C:/data/Will/nnUNet/nnUNet_preprocessed

(nnunet) C:\>nnUNetv2_plan_and_preprocess -d 300
Fingerprint extraction...
Dataset300_redacted
Experiment planning...
Attempting to find 3d_lowres config.
.
.
.
```