### PR TITLE
Update map_channel_name_to_normalization.py

### DIFF
--- a/nnunetv2/preprocessing/normalization/map_channel_name_to_normalization.py
+++ b/nnunetv2/preprocessing/normalization/map_channel_name_to_normalization.py
@@ -7,7 +7,7 @@ channel_name_to_normalization_mapping = {
     'CT': CTNormalization,
     'noNorm': NoNormalization,
     'zscore': ZScoreNormalization,
-    'rescale_0_1': RescaleTo01Normalization,
+    'rescale_to_0_1': RescaleTo01Normalization,
     'rgb_to_0_1': RGBTo01Normalization
 }
 


### PR DESCRIPTION
Hello Fabian,

There is an inconsistency between the documentation (explanation_normalization.md) and the code in the mapping of the different normalization schemes.

Without the proposed change, 'rescale_to_0_1' in the 'channel_names' of 'dataset.json' will trigger 'ZScoreNormalization' instead of 'RescaleTo01Normalization'.

Best,
David