### PR TITLE
Delete LibreOffice's lockfile

### DIFF
--- a/.~lock.metrics.csv#
+++ b/.~lock.metrics.csv#
@@ -1,1 +1,0 @@
-,isensee,E230-PC40.ad.dkfz-heidelberg.de,07.08.2023 14:28,file:///home/isensee/.config/libreoffice/4;


### PR DESCRIPTION
LibreOffice is awesome! But we may not need lockfile in the root directory.