### PR TITLE
Had a previous issue with not readable .npy files: Added a verification step to unpacking, that fixed my problem.

### DIFF
--- a/nnunetv2/training/dataloading/utils.py
+++ b/nnunetv2/training/dataloading/utils.py
@@ -1,12 +1,91 @@
+from __future__ import annotations
 import multiprocessing
 import os
 from multiprocessing import Pool
 from typing import List
+from pathlib import Path
+from warnings import warn
 
 import numpy as np
 from batchgenerators.utilities.file_and_folder_operations import isfile, subfiles
 from nnunetv2.configuration import default_num_processes
 
+
+def find_broken_image_and_labels(
+    path_to_data_dir: str | Path,
+) -> tuple[set[str], set[str]]:
+    """
+    Iterates through all numpys and tries to read them once to see if a ValueError is raised.
+    If so, the case id is added to the respective set and returned for potential fixing.
+
+    :path_to_data_dir: Path/str to the preprocessed directory containing the npys and npzs.
+    :returns: Tuple of a set containing the case ids of the broken npy images and a set of the case ids of broken npy segmentations. 
+    """
+    content = os.listdir(path_to_data_dir)
+    unique_ids = [c.split("_")[0] for c in content if c.endswith("_seg.npy")]
+    failed_data_ids = set()
+    failed_seg_ids = set()
+    for unique_id in unique_ids:
+        # Try reading data
+        try:
+            np.load(path_to_data_dir / (unique_id + ".npy"), "r")
+        except ValueError:
+            failed_data_ids.add(unique_id)
+        # Try reading seg
+        try:
+            np.load(path_to_data_dir / (unique_id + "_seg.npy"), "r")
+        except ValueError:
+            failed_seg_ids.add(unique_id)
+
+    return failed_data_ids, failed_seg_ids
+
+
+def try_fix_broken_npy(path_do_data_dir: Path, case_ids: set[str], fix_image: bool):
+    """ 
+    Receives broken case ids and tries to fix them by re-extracting the npz file (up to 5 times).
+
+    :param case_ids: Set of case ids that are broken.
+    :param path_do_data_dir: Path to the preprocessed directory containing the npys and npzs.
+    :raises ValueError: If the npy file could not be unpacked after 5 tries. --
+    """
+    for case_id in case_ids:
+        for i in range(5):
+            try:
+                key = "data" if fix_image else "seg"
+                suffix = ".npy" if fix_image else "_seg.npy"
+                read_npz = np.load(path_do_data_dir / (case_id + ".npz"), "r")[key]
+                np.save(path_do_data_dir / (case_id + suffix), read_npz)
+                # Try loading the just saved image.
+                np.load(path_do_data_dir / (case_id + suffix), "r")
+                break
+            except ValueError:
+                if i == 4:
+                    raise ValueError(
+                        f"Could not unpack {case_id + suffix} after 5 tries!"
+                    )
+                continue
+
+def verify_or_stratify_npys(path_to_data_dir: str | Path) -> None:
+    """
+    This re-reads the npy files after unpacking. Should there be a loading issue with any, it will try to unpack this file again and overwrites the existing.
+    If the new file does not get saved correctly 5 times, it will raise an error with the file name to the user. Does the same for images and segmentations.
+    :param path_to_data_dir: Path to the preprocessed directory containing the npys and npzs.
+    :raises ValueError: If the npy file could not be unpacked after 5 tries. --
+      Otherwise an obscured error will be raised later during training (depending when the broken file is sampled)
+    """
+    path_to_data_dir = Path(path_to_data_dir)
+    # Check for broken image and segmentation npys
+    failed_data_ids, failed_seg_ids = find_broken_image_and_labels(path_to_data_dir)
+
+    if len(failed_data_ids) != 0 or len(failed_seg_ids) != 0:
+        warn(
+            f"Found {len(failed_data_ids)} faulty data npys and {len(failed_seg_ids)}!\n"
+            + f"Faulty images: {failed_data_ids}; Faulty segmentations: {failed_seg_ids})\n"
+            + "Trying to fix them now."
+        )
+        # Try to fix the broken npys by reextracting the npz. If that fails, raise error
+        try_fix_broken_npy(path_to_data_dir, failed_data_ids, fix_image=True)
+        try_fix_broken_npy(path_to_data_dir, failed_seg_ids, fix_image=False)
 
 def _convert_to_npy(npz_file: str, unpack_segmentation: bool = True, overwrite_existing: bool = False) -> None:
     try:
@@ -34,6 +113,7 @@ def unpack_dataset(folder: str, unpack_segmentation: bool = True, overwrite_exis
                                        [unpack_segmentation] * len(npz_files),
                                        [overwrite_existing] * len(npz_files))
                   )
+    verify_or_stratify_npys(folder)
 
 
 def get_case_identifiers(folder: str) -> List[str]:

--- a/nnunetv2/training/dataloading/utils.py
+++ b/nnunetv2/training/dataloading/utils.py
@@ -22,7 +22,7 @@ def find_broken_image_and_labels(
     :returns: Tuple of a set containing the case ids of the broken npy images and a set of the case ids of broken npy segmentations. 
     """
     content = os.listdir(path_to_data_dir)
-    unique_ids = [c.split("_")[0] for c in content if c.endswith("_seg.npy")]
+    unique_ids = [c[:-4] for c in content if c.endswith(".npz")]
     failed_data_ids = set()
     failed_seg_ids = set()
     for unique_id in unique_ids:


### PR DESCRIPTION
Verifies the npys are readable and if not,
tries to reextract from .npz.
Otherwise faulty extraction can lead to
errors once the broken case is sampled by
dataloading.

Previous error was unreadable .npy file. Due to random sampling could even be thrown after the first epoch but would fail eventually. Error is disguised as can't read pickled file, but the file is corrupted.:

```
2023-08-16 11:38:45.056816: unpacking dataset...
2023-08-16 11:43:43.046134: unpacking done...
2023-08-16 11:43:43.048985: do_dummy_2d_data_aug: True
2023-08-16 11:43:43.053961: Using splits from existing split file: /dkfz/cluster/gpu/data/OE0441/t006d/nnunetv2/preprocessed/Dataset914_medium_overlap_not_background/splits_final.json
2023-08-16 11:43:43.057375: The split file contains 5 splits.
2023-08-16 11:43:43.058902: Desired fold for training: 0
2023-08-16 11:43:43.060317: This split has 314 training and 79 validation cases.
2023-08-16 11:43:43.131137: Unable to plot network architecture:
2023-08-16 11:43:43.133104: No module named 'hiddenlayer'
2023-08-16 11:43:43.144720: 
2023-08-16 11:43:43.146656: Epoch 0
2023-08-16 11:43:43.148475: Current learning rate: 0.01
using pin_memory on device 0
Traceback (most recent call last):
  File "/dkfz/cluster/gpu/data/OE0441/t006d/virtualenvs/nnunetv2/lib/python3.10/site-packages/batchgenerators/dataloading/nondet_multi_threaded_augmenter.py", line 53, in producer
    item = next(data_loader)
  File "/dkfz/cluster/gpu/data/OE0441/t006d/virtualenvs/nnunetv2/lib/python3.10/site-packages/batchgenerators/dataloading/data_loader.py", line 126, in __next__
    return self.generate_train_batch()
  File "/home/t006d/Code/lymph_nodes_quant/nnunetv2/training/dataloading/data_loader_3d.py", line 19, in generate_train_batch
    data, seg, properties = self._data.load_case(i)
  File "/home/t006d/Code/lymph_nodes_quant/nnunetv2/training/dataloading/nnunet_dataset.py", line 86, in load_case
    data = np.load(entry['data_file'][:-4] + ".npy", 'r')
  File "/dkfz/cluster/gpu/data/OE0441/t006d/virtualenvs/nnunetv2/lib/python3.10/site-packages/numpy/lib/npyio.py", line 462, in load
    raise ValueError("Cannot load file containing pickled data "
ValueError: Cannot load file containing pickled data when allow_pickle=False
Exception in background worker 13:
 Cannot load file containing pickled data when allow_pickle=False
using pin_memory on device 0
2023-08-16 11:46:14.807184: train_loss -0.1165
2023-08-16 11:46:14.819525: val_loss -0.4396
2023-08-16 11:46:14.824550: Pseudo dice [0.5286]
2023-08-16 11:46:14.829067: Epoch time: 151.66 s
2023-08-16 11:46:14.830508: Yayy! New best EMA pseudo Dice: 0.5286
2023-08-16 11:46:17.426562: 
2023-08-16 11:46:17.428427: Epoch 1
2023-08-16 11:46:17.430051: Current learning rate: 0.00999
Traceback (most recent call last):
  File "/home/t006d/Code/lymph_nodes_quant/nnunetv2/run/run_training.py", line 274, in <module>
    run_training_entry()
  File "/home/t006d/Code/lymph_nodes_quant/nnunetv2/run/run_training.py", line 268, in run_training_entry
    run_training(args.dataset_name_or_id, args.configuration, args.fold, args.tr, args.p, args.pretrained_weights,
  File "/home/t006d/Code/lymph_nodes_quant/nnunetv2/run/run_training.py", line 204, in run_training
    nnunet_trainer.run_training()
  File "/home/t006d/Code/lymph_nodes_quant/nnunetv2/training/nnUNetTrainer/nnUNetTrainer.py", line 1235, in run_training
    train_outputs.append(self.train_step(next(self.dataloader_train)))
  File "/dkfz/cluster/gpu/data/OE0441/t006d/virtualenvs/nnunetv2/lib/python3.10/site-packages/batchgenerators/dataloading/nondet_multi_threaded_augmenter.py", line 196, in __next__
    item = self.__get_next_item()
  File "/dkfz/cluster/gpu/data/OE0441/t006d/virtualenvs/nnunetv2/lib/python3.10/site-packages/batchgenerators/dataloading/nondet_multi_threaded_augmenter.py", line 181, in __get_next_item
    raise RuntimeError("One or more background workers are no longer alive. Exiting. Please check the "
RuntimeError: One or more background workers are no longer alive. Exiting. Please check the print statements above for the actual error message
Exception in thread Thread-5 (results_loop):
Traceback (most recent call last):
  File "/dkfz/cluster/gpu/data/OE0441/t006d/virtualenvs/nnunetv2/lib/python3.10/threading.py", line 1016, in _bootstrap_inner
    self.run()
  File "/dkfz/cluster/gpu/data/OE0441/t006d/virtualenvs/nnunetv2/lib/python3.10/threading.py", line 953, in run
    self._target(*self._args, **self._kwargs)
  File "/dkfz/cluster/gpu/data/OE0441/t006d/virtualenvs/nnunetv2/lib/python3.10/site-packages/batchgenerators/dataloading/nondet_multi_threaded_augmenter.py", line 125, in results_loop
    raise e
  File "/dkfz/cluster/gpu/data/OE0441/t006d/virtualenvs/nnunetv2/lib/python3.10/site-packages/batchgenerators/dataloading/nondet_multi_threaded_augmenter.py", line 103, in results_loop
    raise RuntimeError("One or more background workers are no longer alive. Exiting. Please check the "
RuntimeError: One or more background workers are no longer alive. Exiting. Please check the print statements above for the actual error message
```