### PR TITLE
Using tuple equality instead of checking element by element

### DIFF
--- a/nnunetv2/experiment_planning/verify_dataset_integrity.py
+++ b/nnunetv2/experiment_planning/verify_dataset_integrity.py
@@ -64,7 +64,7 @@ def check_cases(image_files: List[str], label_file: str, expected_num_channels: 
     # check shapes
     shape_image = images.shape[1:]
     shape_seg = segmentation.shape[1:]
-    if not all([i == j for i, j in zip(shape_image, shape_seg)]):
+    if shape_image != shape_seg:
         print('Error: Shape mismatch between segmentation and corresponding images. \nShape images: %s. '
               '\nShape seg: %s. \nImage files: %s. \nSeg file: %s\n' %
               (shape_image, shape_seg, image_files, label_file))

--- a/nnunetv2/imageio/base_reader_writer.py
+++ b/nnunetv2/imageio/base_reader_writer.py
@@ -23,10 +23,7 @@ class BaseReaderWriter(ABC):
     def _check_all_same(input_list):
         # compare all entries to the first
         for i in input_list[1:]:
-            if not len(i) == len(input_list[0]):
-                return False
-            all_same = all(i[j] == input_list[0][j] for j in range(len(i)))
-            if not all_same:
+            if i != input_list[0]:
                 return False
         return True
 
@@ -34,10 +31,7 @@ class BaseReaderWriter(ABC):
     def _check_all_same_array(input_list):
         # compare all entries to the first
         for i in input_list[1:]:
-            if not all([a == b for a, b in zip(i.shape, input_list[0].shape)]):
-                return False
-            all_same = np.allclose(i, input_list[0])
-            if not all_same:
+            if i.shape != input_list[0].shape or not np.allclose(i, input_list[0]):
                 return False
         return True
 

--- a/nnunetv2/training/loss/dice.py
+++ b/nnunetv2/training/loss/dice.py
@@ -79,7 +79,7 @@ class MemoryEfficientSoftDiceLoss(nn.Module):
             if len(x.shape) != len(y.shape):
                 y = y.view((y.shape[0], 1, *y.shape[1:]))
 
-            if all([i == j for i, j in zip(x.shape, y.shape)]):
+            if x.shape == y.shape:
                 # if this is the case then gt is probably already a one hot encoding
                 y_onehot = y
             else:
@@ -137,7 +137,7 @@ def get_tp_fp_fn_tn(net_output, gt, axes=None, mask=None, square=False):
         if len(shp_x) != len(shp_y):
             gt = gt.view((shp_y[0], 1, *shp_y[1:]))
 
-        if all([i == j for i, j in zip(net_output.shape, gt.shape)]):
+        if net_output.shape == gt.shape:
             # if this is the case then gt is probably already a one hot encoding
             y_onehot = gt
         else:

--- a/nnunetv2/utilities/overlay_plots.py
+++ b/nnunetv2/utilities/overlay_plots.py
@@ -136,7 +136,7 @@ def plot_overlay(image_file: str, segmentation_file: str, image_reader_writer: B
     seg, props_seg = image_reader_writer.read_seg(segmentation_file)
     seg = seg[0]
 
-    assert all([i == j for i, j in zip(image.shape, seg.shape)]), "image and seg do not have the same shape: %s, %s" % (
+    assert image.shape == seg.shape, "image and seg do not have the same shape: %s, %s" % (
         image_file, segmentation_file)
 
     assert len(image.shape) == 3, 'only 3D images/segs are supported'


### PR DESCRIPTION
Python supports tuple and list equality and it is more clear and slightly faster (if this matters) than `all([a == b for a, b in zip(x, y)]`.
```py
>>> (1, 2, 3) == (1, 2, 3)
True
>>> (1, 2, 3) == (1, 2,)
False
>>> [1, 2, 3] == [1, 2, 3]
True
>>> [1, 2, 3] == [1, 2]
False
>>> [1, 2] == (1, 2)
False
```