### PR TITLE
Turning on compression for SimpleITK writer.

### DIFF
--- a/nnunetv2/imageio/simpleitk_reader_writer.py
+++ b/nnunetv2/imageio/simpleitk_reader_writer.py
@@ -126,4 +126,4 @@ class SimpleITKIO(BaseReaderWriter):
         itk_image.SetOrigin(properties['sitk_stuff']['origin'])
         itk_image.SetDirection(properties['sitk_stuff']['direction'])
 
-        sitk.WriteImage(itk_image, output_fname)
+        sitk.WriteImage(itk_image, output_fname, True)


### PR DESCRIPTION
When saving segmentation in nrrd format without compression the file size is significantly larger than with compression, 20mb versus 19kb for a 5000x4000 nrrd binary segmentation.