### PR TITLE
Refactor _internal_maybe_mirror_and_predict function

### DIFF
--- a/nnunetv2/inference/predict_from_raw_data.py
+++ b/nnunetv2/inference/predict_from_raw_data.py
@@ -553,7 +553,7 @@ class nnUNetPredictor(object):
             axes_combinations = [
                 c for i in range(len(mirror_axes)) for c in itertools.combinations([m + 2 for m in mirror_axes], i + 1)
             ]
-            prediction = sum(torch.flip(self.network(torch.flip(x, (*axes,))), (*axes,)) for axes in axes_combinations]
+            prediction = sum([torch.flip(self.network(torch.flip(x, (*axes,))), (*axes,)) for axes in axes_combinations])
             prediction /= num_predictons
         return prediction
 

--- a/nnunetv2/inference/predict_from_raw_data.py
+++ b/nnunetv2/inference/predict_from_raw_data.py
@@ -553,7 +553,8 @@ class nnUNetPredictor(object):
             axes_combinations = [
                 c for i in range(len(mirror_axes)) for c in itertools.combinations([m + 2 for m in mirror_axes], i + 1)
             ]
-            prediction = sum([torch.flip(self.network(torch.flip(x, (*axes,))), (*axes,)) for axes in axes_combinations])
+            for axes in axes_combinations:
+                prediction += torch.flip(self.network(torch.flip(x, (*axes,))), (*axes,))
             prediction /= num_predictons
         return prediction
 


### PR DESCRIPTION
This PR replaced the multiple if statements with a single loop that uses itertools.combinations to generate all possible axes combinations for mirroring. This reduces code duplication and (hopefully😉) improves readability and maintainability.