### PR TITLE
Add ONNX exporter

### DIFF
--- a/nnunetv2/model_sharing/entry_points.py
+++ b/nnunetv2/model_sharing/entry_points.py
@@ -1,6 +1,9 @@
+from pathlib import Path
+
 from nnunetv2.model_sharing.model_download import download_and_install_from_url
 from nnunetv2.model_sharing.model_export import export_pretrained_model
 from nnunetv2.model_sharing.model_import import install_model_from_zip_file
+from nnunetv2.model_sharing.onnx_export import export_onnx_model
 
 
 def print_license_warning():
@@ -51,7 +54,7 @@ def export_pretrained_model_entry():
     parser.add_argument('-p', required=False, type=str, default='nnUNetPlans', help='plans identifier')
     parser.add_argument('-f', required=False, nargs='+', type=str, default=(0, 1, 2, 3, 4), help='list of fold ids')
     parser.add_argument('-chk', required=False, nargs='+', type=str, default=('checkpoint_final.pth', ),
-                        help='Lis tof checkpoint names to export. Default: checkpoint_final.pth')
+                        help='List of checkpoint names to export. Default: checkpoint_final.pth')
     parser.add_argument('--not_strict', action='store_false', default=False, required=False, help='Set this to allow missing folds and/or configurations')
     parser.add_argument('--exp_cv_preds', action='store_true', required=False, help='Set this to export the cross-validation predictions as well')
     args = parser.parse_args()
@@ -59,3 +62,41 @@ def export_pretrained_model_entry():
     export_pretrained_model(dataset_name_or_id=args.d, output_file=args.o, configurations=args.c, trainer=args.tr,
                             plans_identifier=args.p, folds=args.f, strict=not args.not_strict, save_checkpoints=args.chk,
                             export_crossval_predictions=args.exp_cv_preds)
+
+
+def export_pretrained_model_onnx_entry():
+    import argparse
+    parser = argparse.ArgumentParser(
+        description="Use this to export a trained model to ONNX format."
+                    "You are responsible for creating the ONNX pipeline yourself.")
+    parser.add_argument('-d', type=str, required=True, help='Dataset name or id')
+    parser.add_argument('-o', type=Path, required=True, help='Output directory')
+    parser.add_argument('-c', nargs='+', type=str, required=False,
+                        default=('3d_lowres', '3d_fullres', '2d', '3d_cascade_fullres'),
+                        help="List of configuration names")
+    parser.add_argument('-tr', required=False, type=str, default='nnUNetTrainer', help='Trainer class')
+    parser.add_argument('-p', required=False, type=str, default='nnUNetPlans', help='plans identifier')
+    parser.add_argument('-f', required=False, nargs='+', type=str, default=None, help='list of fold ids')
+    parser.add_argument('-chk', required=False, nargs='+', type=str, default=('checkpoint_final.pth', ),
+                        help='List of checkpoint names to export. Default: checkpoint_final.pth')
+    parser.add_argument('--not_strict', action='store_false', default=False, required=False, help='Set this to allow missing folds and/or configurations')
+    parser.add_argument('--exp_cv_preds', action='store_true', required=False, help='Set this to export the cross-validation predictions as well')
+    args = parser.parse_args()
+
+    print('######################################################')
+    print('!!!!!!!!!!!!!!!!!!!!!!!!WARNING!!!!!!!!!!!!!!!!!!!!!!!')
+    print('######################################################')
+    print("You are responsible for creating the ONNX pipeline \n"
+          "yourself.\n\n"
+          "This script will only export the model \n"
+          "weights to an onnx file, and some basic information \n"
+          "about the model. You will have to create the ONNX \n"
+          "pipeline yourself. \n")
+    print("See https://pytorch.org/tutorials/beginner/onnx/export_simple_model_to_onnx_tutorial.html#execute-the-onnx-model-with-onnx-runtime\n"
+          "for some documentation on how to do this.")
+    print('######################################################')
+    print('')
+
+    export_onnx_model(dataset_name_or_id=args.d, output_dir=args.o, configurations=args.c, trainer=args.tr,
+                      plans_identifier=args.p, folds=args.f, strict=not args.not_strict, save_checkpoints=args.chk,
+                      export_crossval_predictions=args.exp_cv_preds)

--- a/nnunetv2/model_sharing/entry_points.py
+++ b/nnunetv2/model_sharing/entry_points.py
@@ -7,25 +7,29 @@ from nnunetv2.model_sharing.onnx_export import export_onnx_model
 
 
 def print_license_warning():
-    print('')
-    print('######################################################')
-    print('!!!!!!!!!!!!!!!!!!!!!!!!WARNING!!!!!!!!!!!!!!!!!!!!!!!')
-    print('######################################################')
-    print("Using the pretrained model weights is subject to the license of the dataset they were trained on. Some "
-          "allow commercial use, others don't. It is your responsibility to make sure you use them appropriately! Use "
-          "nnUNet_print_pretrained_model_info(task_name) to see a summary of the dataset and where to find its license!")
-    print('######################################################')
-    print('')
+    print("")
+    print("######################################################")
+    print("!!!!!!!!!!!!!!!!!!!!!!!!WARNING!!!!!!!!!!!!!!!!!!!!!!!")
+    print("######################################################")
+    print(
+        "Using the pretrained model weights is subject to the license of the dataset they were trained on. Some "
+        "allow commercial use, others don't. It is your responsibility to make sure you use them appropriately! Use "
+        "nnUNet_print_pretrained_model_info(task_name) to see a summary of the dataset and where to find its license!"
+    )
+    print("######################################################")
+    print("")
 
 
 def download_by_url():
     import argparse
+
     parser = argparse.ArgumentParser(
         description="Use this to download pretrained models. This script is intended to download models via url only. "
-                    "CAREFUL: This script will overwrite "
-                    "existing models (if they share the same trainer class and plans as "
-                    "the pretrained model.")
-    parser.add_argument("url", type=str, help='URL of the pretrained model')
+        "CAREFUL: This script will overwrite "
+        "existing models (if they share the same trainer class and plans as "
+        "the pretrained model."
+    )
+    parser.add_argument("url", type=str, help="URL of the pretrained model")
     args = parser.parse_args()
     url = args.url
     download_and_install_from_url(url)
@@ -33,9 +37,11 @@ def download_by_url():
 
 def install_from_zip_entry_point():
     import argparse
+
     parser = argparse.ArgumentParser(
-        description="Use this to install a zip file containing a pretrained model.")
-    parser.add_argument("zip", type=str, help='zip file')
+        description="Use this to install a zip file containing a pretrained model."
+    )
+    parser.add_argument("zip", type=str, help="zip file")
     args = parser.parse_args()
     zip = args.zip
     install_model_from_zip_file(zip)
@@ -43,60 +49,146 @@ def install_from_zip_entry_point():
 
 def export_pretrained_model_entry():
     import argparse
+
     parser = argparse.ArgumentParser(
-        description="Use this to export a trained model as a zip file.")
-    parser.add_argument('-d', type=str, required=True, help='Dataset name or id')
-    parser.add_argument('-o', type=str, required=True, help='Output file name')
-    parser.add_argument('-c', nargs='+', type=str, required=False,
-                        default=('3d_lowres', '3d_fullres', '2d', '3d_cascade_fullres'),
-                        help="List of configuration names")
-    parser.add_argument('-tr', required=False, type=str, default='nnUNetTrainer', help='Trainer class')
-    parser.add_argument('-p', required=False, type=str, default='nnUNetPlans', help='plans identifier')
-    parser.add_argument('-f', required=False, nargs='+', type=str, default=(0, 1, 2, 3, 4), help='list of fold ids')
-    parser.add_argument('-chk', required=False, nargs='+', type=str, default=('checkpoint_final.pth', ),
-                        help='List of checkpoint names to export. Default: checkpoint_final.pth')
-    parser.add_argument('--not_strict', action='store_false', default=False, required=False, help='Set this to allow missing folds and/or configurations')
-    parser.add_argument('--exp_cv_preds', action='store_true', required=False, help='Set this to export the cross-validation predictions as well')
+        description="Use this to export a trained model as a zip file."
+    )
+    parser.add_argument("-d", type=str, required=True, help="Dataset name or id")
+    parser.add_argument("-o", type=str, required=True, help="Output file name")
+    parser.add_argument(
+        "-c",
+        nargs="+",
+        type=str,
+        required=False,
+        default=("3d_lowres", "3d_fullres", "2d", "3d_cascade_fullres"),
+        help="List of configuration names",
+    )
+    parser.add_argument(
+        "-tr", required=False, type=str, default="nnUNetTrainer", help="Trainer class"
+    )
+    parser.add_argument(
+        "-p", required=False, type=str, default="nnUNetPlans", help="plans identifier"
+    )
+    parser.add_argument(
+        "-f",
+        required=False,
+        nargs="+",
+        type=str,
+        default=(0, 1, 2, 3, 4),
+        help="list of fold ids",
+    )
+    parser.add_argument(
+        "-chk",
+        required=False,
+        nargs="+",
+        type=str,
+        default=("checkpoint_final.pth",),
+        help="List of checkpoint names to export. Default: checkpoint_final.pth",
+    )
+    parser.add_argument(
+        "--not_strict",
+        action="store_false",
+        default=False,
+        required=False,
+        help="Set this to allow missing folds and/or configurations",
+    )
+    parser.add_argument(
+        "--exp_cv_preds",
+        action="store_true",
+        required=False,
+        help="Set this to export the cross-validation predictions as well",
+    )
     args = parser.parse_args()
 
-    export_pretrained_model(dataset_name_or_id=args.d, output_file=args.o, configurations=args.c, trainer=args.tr,
-                            plans_identifier=args.p, folds=args.f, strict=not args.not_strict, save_checkpoints=args.chk,
-                            export_crossval_predictions=args.exp_cv_preds)
+    export_pretrained_model(
+        dataset_name_or_id=args.d,
+        output_file=args.o,
+        configurations=args.c,
+        trainer=args.tr,
+        plans_identifier=args.p,
+        folds=args.f,
+        strict=not args.not_strict,
+        save_checkpoints=args.chk,
+        export_crossval_predictions=args.exp_cv_preds,
+    )
 
 
 def export_pretrained_model_onnx_entry():
     import argparse
+
     parser = argparse.ArgumentParser(
         description="Use this to export a trained model to ONNX format."
-                    "You are responsible for creating the ONNX pipeline yourself.")
-    parser.add_argument('-d', type=str, required=True, help='Dataset name or id')
-    parser.add_argument('-o', type=Path, required=True, help='Output directory')
-    parser.add_argument('-c', nargs='+', type=str, required=False,
-                        default=('3d_lowres', '3d_fullres', '2d', '3d_cascade_fullres'),
-                        help="List of configuration names")
-    parser.add_argument('-tr', required=False, type=str, default='nnUNetTrainer', help='Trainer class')
-    parser.add_argument('-p', required=False, type=str, default='nnUNetPlans', help='plans identifier')
-    parser.add_argument('-f', required=False, nargs='+', type=str, default=None, help='list of fold ids')
-    parser.add_argument('-chk', required=False, nargs='+', type=str, default=('checkpoint_final.pth', ),
-                        help='List of checkpoint names to export. Default: checkpoint_final.pth')
-    parser.add_argument('--not_strict', action='store_false', default=False, required=False, help='Set this to allow missing folds and/or configurations')
-    parser.add_argument('--exp_cv_preds', action='store_true', required=False, help='Set this to export the cross-validation predictions as well')
+        "You are responsible for creating the ONNX pipeline yourself."
+    )
+    parser.add_argument("-d", type=str, required=True, help="Dataset name or id")
+    parser.add_argument("-o", type=Path, required=True, help="Output directory")
+    parser.add_argument(
+        "-c",
+        nargs="+",
+        type=str,
+        required=False,
+        default=("3d_lowres", "3d_fullres", "2d", "3d_cascade_fullres"),
+        help="List of configuration names",
+    )
+    parser.add_argument(
+        "-tr", required=False, type=str, default="nnUNetTrainer", help="Trainer class"
+    )
+    parser.add_argument(
+        "-p", required=False, type=str, default="nnUNetPlans", help="plans identifier"
+    )
+    parser.add_argument(
+        "-f", required=False, nargs="+", type=str, default=None, help="list of fold ids"
+    )
+    parser.add_argument(
+        "-chk",
+        required=False,
+        nargs="+",
+        type=str,
+        default=("checkpoint_final.pth",),
+        help="List of checkpoint names to export. Default: checkpoint_final.pth",
+    )
+    parser.add_argument(
+        "--not_strict",
+        action="store_false",
+        default=False,
+        required=False,
+        help="Set this to allow missing folds and/or configurations",
+    )
+    parser.add_argument(
+        "--exp_cv_preds",
+        action="store_true",
+        required=False,
+        help="Set this to export the cross-validation predictions as well",
+    )
     args = parser.parse_args()
 
-    print('######################################################')
-    print('!!!!!!!!!!!!!!!!!!!!!!!!WARNING!!!!!!!!!!!!!!!!!!!!!!!')
-    print('######################################################')
-    print("You are responsible for creating the ONNX pipeline \n"
-          "yourself.\n\n"
-          "This script will only export the model \n"
-          "weights to an onnx file, and some basic information \n"
-          "about the model. You will have to create the ONNX \n"
-          "pipeline yourself. \n")
-    print("See https://pytorch.org/tutorials/beginner/onnx/export_simple_model_to_onnx_tutorial.html#execute-the-onnx-model-with-onnx-runtime\n"
-          "for some documentation on how to do this.")
-    print('######################################################')
-    print('')
+    print("######################################################")
+    print("!!!!!!!!!!!!!!!!!!!!!!!!WARNING!!!!!!!!!!!!!!!!!!!!!!!")
+    print("######################################################")
+    print(
+        "You are responsible for creating the ONNX pipeline \n"
+        "yourself.\n\n"
+        "This script will only export the model \n"
+        "weights to an onnx file, and some basic information \n"
+        "about the model. You will have to create the ONNX \n"
+        "pipeline yourself. \n"
+    )
+    print(
+        "See\n"
+        "https://pytorch.org/tutorials/beginner/onnx/export_simple_model_to_onnx_tutorial.html"
+        "#execute-the-onnx-model-with-onnx-runtime\n"
+        "for some documentation on how to do this."
+    )
+    print("######################################################")
+    print("")
 
-    export_onnx_model(dataset_name_or_id=args.d, output_dir=args.o, configurations=args.c, trainer=args.tr,
-                      plans_identifier=args.p, folds=args.f, strict=not args.not_strict, save_checkpoints=args.chk,
-                      export_crossval_predictions=args.exp_cv_preds)
+    export_onnx_model(
+        dataset_name_or_id=args.d,
+        output_dir=args.o,
+        configurations=args.c,
+        trainer=args.tr,
+        plans_identifier=args.p,
+        folds=args.f,
+        strict=not args.not_strict,
+        save_checkpoints=args.chk,
+    )

--- a/nnunetv2/model_sharing/onnx_export.py
+++ b/nnunetv2/model_sharing/onnx_export.py
@@ -1,0 +1,120 @@
+import json
+from os.path import isdir
+from pathlib import Path
+from typing import Tuple, Union
+
+import torch
+from torch._dynamo import OptimizedModule
+
+from nnunetv2.inference.predict_from_raw_data import nnUNetPredictor
+from nnunetv2.utilities.dataset_name_id_conversion import \
+    maybe_convert_to_dataset_name
+from nnunetv2.utilities.file_path_utilities import get_output_folder
+
+
+def export_onnx_model(
+    dataset_name_or_id: Union[int, str],
+    output_dir: Path,
+    configurations: Tuple[str] = (
+        "2d",
+        "3d_lowres",
+        "3d_fullres",
+        "3d_cascade_fullres",
+    ),
+    trainer: str = "nnUNetTrainer",
+    plans_identifier: str = "nnUNetPlans",
+    folds: Tuple[Union[int, str], ...] = (0, 1, 2, 3, 4),
+    strict: bool = True,
+    save_checkpoints: Tuple[str, ...] = ("checkpoint_final.pth",),
+    output_names: tuple[str, ...] = None,
+) -> None:
+    if not output_names:
+        output_names = (f"{checkpoint[:-4]}.onnx" for checkpoint in save_checkpoints)
+
+    dataset_name = maybe_convert_to_dataset_name(dataset_name_or_id)
+    for c in configurations:
+        print(f"Configuration {c}")
+        trainer_output_dir = get_output_folder(
+            dataset_name, trainer, plans_identifier, c
+        )
+
+        if not isdir(trainer_output_dir):
+            if strict:
+                raise RuntimeError(
+                    f"{dataset_name} is missing the trained model of configuration {c}"
+                )
+            else:
+                print(f"Skipping configuration {c}, does not exist")
+                continue
+
+        predictor = nnUNetPredictor(
+            perform_everything_on_gpu=False,
+            device=torch.device("cpu"),
+        )
+
+        for checkpoint_name, output_name in zip(save_checkpoints, output_names):
+            predictor.initialize_from_trained_model_folder(
+                model_training_output_dir=trainer_output_dir,
+                use_folds=folds,
+                checkpoint_name=checkpoint_name,
+            )
+
+            list_of_parameters = predictor.list_of_parameters
+            network = predictor.network
+            config = predictor.configuration_manager
+
+            for fold, params in zip(folds, list_of_parameters):
+                if not isinstance(network, OptimizedModule):
+                    network.load_state_dict(params)
+                else:
+                    network._orig_mod.load_state_dict(params)
+
+                network.eval()
+
+                export_options = torch.onnx.ExportOptions(dynamic_shapes=True)
+                rand_input = torch.rand((1, 1, *config.patch_size))
+                traced_model = torch.onnx.dynamo_export(
+                    network,
+                    rand_input,
+                    export_options=export_options,
+                )
+
+                curr_output_dir = output_dir / c / f"fold_{fold}"
+                if not curr_output_dir.exists():
+                    curr_output_dir.mkdir(parents=True)
+                else:
+                    if len(list(curr_output_dir.iterdir())) > 0:
+                        raise RuntimeError(
+                            f"Output directory {curr_output_dir} is not empty"
+                        )
+
+                traced_model.save(str(curr_output_dir / output_name))
+                with open(curr_output_dir / "config.json", "w") as f:
+                    json.dump(
+                        {
+                            "dataset_name": dataset_name,
+                            "configuration": c,
+                            "trainer": trainer,
+                            "plans_identifier": plans_identifier,
+                            "fold": fold,
+                            "checkpoint_name": checkpoint_name,
+                            "configuration_manager": {
+                                k: config.configuration[k]
+                                for k in [
+                                    "patch_size",
+                                    "spacing",
+                                    "normalization_schemes",
+                                    # These are mostly interesting for certification
+                                    # uses, but they are also useful for debugging.
+                                    "UNet_class_name",
+                                    "UNet_base_num_features",
+                                    "unet_max_num_features",
+                                    "conv_kernel_sizes",
+                                    "pool_op_kernel_sizes",
+                                    "num_pool_per_axis",
+                                ]
+                            },
+                        },
+                        f,
+                        indent=4,
+                    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ nnUNetv2_plot_overlay_pngs = "nnunetv2.utilities.overlay_plots:entry_point_gener
 nnUNetv2_download_pretrained_model_by_url = "nnunetv2.model_sharing.entry_points:download_by_url"
 nnUNetv2_install_pretrained_model_from_zip = "nnunetv2.model_sharing.entry_points:install_from_zip_entry_point"
 nnUNetv2_export_model_to_zip = "nnunetv2.model_sharing.entry_points:export_pretrained_model_entry"
+nnUNetv2_export_model_to_onnx = "nnunetv2.model_sharing.entry_points:export_pretrained_model_onnx_entry"
 nnUNetv2_move_plans_between_datasets = "nnunetv2.experiment_planning.plans_for_pretraining.move_plans_between_datasets:entry_point_move_plans_between_datasets"
 nnUNetv2_evaluate_folder = "nnunetv2.evaluation.evaluate_predictions:evaluate_folder_entry_point"
 nnUNetv2_evaluate_simple = "nnunetv2.evaluation.evaluate_predictions:evaluate_simple_entry_point"
@@ -84,6 +85,11 @@ dev = [
     "black",
     "ruff",
     "pre-commit"
+]
+onnx-export = [
+    "onnx",
+    "onnxscript",
+    "onnxruntime",
 ]
 
 [tool.codespell]


### PR DESCRIPTION
# Draft

This pull request is still a draft, pending some quick testing. Therefore, it currently serves as a gauge of interest from the current maintainers.

# Purpose

Hey there! I, and others, have occasionally wondered if it was possible to export the trained nnU-Nets to an ONNX format, for deployment, or other sharing. To this end, I've cobbled together an exporter using the built-in pytorch ONNX exporter.

In the past, I had managed to get [an exporter working for v1](#1144), but this won't work since the release of v2 changed some things around. Nevertheless, the exported information let us build a very minimalist copy of the entire nnU-Net pipeline that produced outputs faster than the v1 inference pipeline, and with less overhead.

# Implementation

I've "repurposed" bits and pieces of code I found around the project (Mainly `nnunetv2.inference.predict_from_raw_data.py`) to load in a network, set the parameters and acquire any information the user might want to build their own ONNX pipeline. The command works roughly the same as the `nnUNetv2_export_model_to_zip` command, but exports an `.onnx` file for each fold and configuration combination instead. Each `.onnx` file should be accompanied with a `.json` file that has some basic information the user might want to know to build their own ONNX pipeline with.

Finally, it's made perfectly clear that any ONNX pipelining is the sole responsibility of the end-user, not the maintainers of nnU-Net through a big warning box which is printed before the export begins.

# Motivation

While I can't speak for any others' reasons, our main reason to want an ONNX format is the deployment of the trained models to an inference server. Due to server costs, we might want to use some of ONNX's excellent optimization techniques for faster inference, maybe move away from a python-based pipeline in favor of compiled languages, like C. C++ or Rust. Finally, a lot of CUDA+Python Docker containers produce gigantic files (for example, the docker image I use to train the nnU-Nets is 24GB when exported), which will take an extremely long time to boot up on servers.

A lot of clinicians really would like to see neural networks applied in their practice, and quite a few companies are willing make that investment. However, server costs are still a large burden, so any ability to offer a way to export an nnU-Net to a common format, even without further support beyond the exporter, will hopefully allow a larger adoption outside of pure research across the board.