### PR TITLE
Adding build-system to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,10 @@ dev = [
     "pre-commit"
 ]
 
+[build-system]
+requires = ["setuptools>=69.0.2"]
+build-backend = "setuptools.build_meta"
+
 [tool.codespell]
 skip = '.git,*.pdf,*.svg'
 #


### PR DESCRIPTION
If using an older version of setuptools, the installation of nnunet fails (#1832). Adding the requirement of using setuptoosl >=69.0.2 should resolve this issue.

I had no time to test it yet, and it might also work with lower version of setup_tools than 69.0.2. Before merging this should be tested.