### PR TITLE
Add PyTorch Checkpoint Export and Load

### DIFF
--- a/nnunetv2/model_sharing/entry_points.py
+++ b/nnunetv2/model_sharing/entry_points.py
@@ -1,5 +1,5 @@
 from nnunetv2.model_sharing.model_download import download_and_install_from_url
-from nnunetv2.model_sharing.model_export import export_pretrained_model
+from nnunetv2.model_sharing.model_export import export_pretrained_model, export_model_checkpoint
 from nnunetv2.model_sharing.model_import import install_model_from_zip_file
 
 
@@ -59,3 +59,19 @@ def export_pretrained_model_entry():
     export_pretrained_model(dataset_name_or_id=args.d, output_file=args.o, configurations=args.c, trainer=args.tr,
                             plans_identifier=args.p, folds=args.f, strict=not args.not_strict, save_checkpoints=args.chk,
                             export_crossval_predictions=args.exp_cv_preds)
+
+
+def export_model_to_checkpoint():
+    import argparse
+    parser = argparse.ArgumentParser(description="Export nnunet model checkpoint as a single .pth file")
+    parser.add_argument("--path", type=str, help="path to nnunet model directory")
+    parser.add_argument("--checkpoint_path", type=str, help="path to save the checkpoint", required=False, default=None)
+    parser.add_argument("--checkpoint_name", type=str, help="name of the checkpoint", required=False, default="model_checkpoint.pth",)
+
+    args = parser.parse_args()
+
+    export_model_checkpoint(
+        path=args.path,
+        checkpoint_path=args.checkpoint_path,
+        checkpoint_name=args.checkpoint_name,
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ nnUNetv2_plot_overlay_pngs = "nnunetv2.utilities.overlay_plots:entry_point_gener
 nnUNetv2_download_pretrained_model_by_url = "nnunetv2.model_sharing.entry_points:download_by_url"
 nnUNetv2_install_pretrained_model_from_zip = "nnunetv2.model_sharing.entry_points:install_from_zip_entry_point"
 nnUNetv2_export_model_to_zip = "nnunetv2.model_sharing.entry_points:export_pretrained_model_entry"
+nnUNetv2_export_model_to_checkpoint = "nnunetv2.model_sharing.entry_points:export_model_to_checkpoint"
 nnUNetv2_move_plans_between_datasets = "nnunetv2.experiment_planning.plans_for_pretraining.move_plans_between_datasets:entry_point_move_plans_between_datasets"
 nnUNetv2_evaluate_folder = "nnunetv2.evaluation.evaluate_predictions:evaluate_folder_entry_point"
 nnUNetv2_evaluate_simple = "nnunetv2.evaluation.evaluate_predictions:evaluate_simple_entry_point"


### PR DESCRIPTION
Similar to #1826, it would be conveient to be able to share a single .pt checkpoint file. 

This PR adds:
- Exporter cli for exporting a trained nnunet model as a single pytorch checkpoint file.
- Reader for loading trained nnunet model from a single pytorch checkpoint file. 
 
There is already the zip exporter, but that has a lot of additional data that isn't required if you only want to use the model for inference. 
