### PR TITLE
Improving normalization by reducing memory allocations

### DIFF
--- a/nnunetv2/preprocessing/normalization/default_normalization_schemes.py
+++ b/nnunetv2/preprocessing/normalization/default_normalization_schemes.py
@@ -32,7 +32,7 @@ class ZScoreNormalization(ImageNormalization):
         here seg is used to store the zero valued region. The value for that region in the segmentation is -1 by
         default.
         """
-        image = image.astype(self.target_dtype)
+        image = image.astype(self.target_dtype, copy=False)
         if self.use_mask_for_norm is not None and self.use_mask_for_norm:
             # negative values in the segmentation encode the 'outside' region (think zero values around the brain as
             # in BraTS). We want to run the normalization only in the brain region, so we need to mask the image.
@@ -45,7 +45,8 @@ class ZScoreNormalization(ImageNormalization):
         else:
             mean = image.mean()
             std = image.std()
-            image = (image - mean) / (max(std, 1e-8))
+            image -= mean
+            image /= (max(std, 1e-8))
         return image
 
 
@@ -54,13 +55,15 @@ class CTNormalization(ImageNormalization):
 
     def run(self, image: np.ndarray, seg: np.ndarray = None) -> np.ndarray:
         assert self.intensityproperties is not None, "CTNormalization requires intensity properties"
-        image = image.astype(self.target_dtype)
         mean_intensity = self.intensityproperties['mean']
         std_intensity = self.intensityproperties['std']
         lower_bound = self.intensityproperties['percentile_00_5']
         upper_bound = self.intensityproperties['percentile_99_5']
-        image = np.clip(image, lower_bound, upper_bound)
-        image = (image - mean_intensity) / max(std_intensity, 1e-8)
+
+        image = image.astype(self.target_dtype, copy=False)
+        np.clip(image, lower_bound, upper_bound, out=image)
+        image -= mean_intensity
+        image /= max(std_intensity, 1e-8)
         return image
 
 
@@ -68,16 +71,16 @@ class NoNormalization(ImageNormalization):
     leaves_pixels_outside_mask_at_zero_if_use_mask_for_norm_is_true = False
 
     def run(self, image: np.ndarray, seg: np.ndarray = None) -> np.ndarray:
-        return image.astype(self.target_dtype)
+        return image.astype(self.target_dtype, copy=False)
 
 
 class RescaleTo01Normalization(ImageNormalization):
     leaves_pixels_outside_mask_at_zero_if_use_mask_for_norm_is_true = False
 
     def run(self, image: np.ndarray, seg: np.ndarray = None) -> np.ndarray:
-        image = image.astype(self.target_dtype)
-        image = image - image.min()
-        image = image / np.clip(image.max(), a_min=1e-8, a_max=None)
+        image = image.astype(self.target_dtype, copy=False)
+        image -= image.min()
+        image /= np.clip(image.max(), a_min=1e-8, a_max=None)
         return image
 
 
@@ -89,7 +92,7 @@ class RGBTo01Normalization(ImageNormalization):
                                  "Your images do not seem to be RGB images"
         assert image.max() <= 255, "RGB images are uint 8, for whatever reason I found pixel values greater than 255" \
                                    ". Your images do not seem to be RGB images"
-        image = image.astype(self.target_dtype)
-        image = image / 255.
+        image = image.astype(self.target_dtype, copy=False)
+        image /= 255.
         return image
 


### PR DESCRIPTION
* using `np.ndarray.astype(..., copy=False)` to prevent new array creation when the types are the same
* using inplace numpy matrix operations
* using inplace `np.clip`

This version is up to 20x times faster for big `(512, 512, 512)` CT cases.