### PR TITLE
Clarify usage of `predict_single_npy_array` re: SimpleITK axis ordering

### DIFF
--- a/nnunetv2/inference/predict_from_raw_data.py
+++ b/nnunetv2/inference/predict_from_raw_data.py
@@ -422,6 +422,9 @@ class nnUNetPredictor(object):
                                  output_file_truncated: str = None,
                                  save_or_return_probabilities: bool = False):
         """
+        input_image must use SimpleITK axis ordering!
+            (NB: if array comes from a nibabel-loaded image, you must swap the
+             axes of both the array *and* the spacing from [x,y,z] to [z,y,x]!)
         image_properties must only have a 'spacing' key!
         """
         ppa = PreprocessAdapterFromNpy([input_image], [segmentation_previous_stage], [image_properties],

--- a/nnunetv2/inference/predict_from_raw_data.py
+++ b/nnunetv2/inference/predict_from_raw_data.py
@@ -422,6 +422,8 @@ class nnUNetPredictor(object):
                                  output_file_truncated: str = None,
                                  save_or_return_probabilities: bool = False):
         """
+        WARNING: SLOW. ONLY USE THIS IF YOU CANNOT GIVE NNUNET MULTIPLE IMAGES AT ONCE FOR SOME REASON.
+
         input_image must use SimpleITK axis ordering!
             (NB: if array comes from a nibabel-loaded image, you must swap the
              axes of both the array *and* the spacing from [x,y,z] to [z,y,x]!)

--- a/nnunetv2/inference/readme.md
+++ b/nnunetv2/inference/readme.md
@@ -147,6 +147,7 @@ cons:
 
 tldr:
 - you give one image as npy array
+- array must use [SimpleITK axis order](http://insightsoftwareconsortium.github.io/SimpleITK-Notebooks/Python_html/03_Image_Details.html#Conversion-between-numpy-and-SimpleITK) (see examples below)
 - everything is done in the main process: preprocessing, prediction, resampling, (export)
 - no interlacing, slowest variant!
 - ONLY USE THIS IF YOU CANNOT GIVE NNUNET MULTIPLE IMAGES AT ONCE FOR SOME REASON
@@ -160,8 +161,14 @@ cons:
 - never the right choice unless you can only give a single image at a time to nnU-Net
 
 ```python
-    # predict a single numpy array
+    # predict a single numpy array (SimpleITK)
     img, props = SimpleITKIO().read_images([join(nnUNet_raw, 'Dataset003_Liver/imagesTr/liver_63_0000.nii.gz')])
+    ret = predictor.predict_single_npy_array(img, props, None, None, False)
+
+    # predict a single numpy array (Nibabel with axes swapped)
+    img_nii = nib.load('Dataset003_Liver/imagesTr/liver_63_0000.nii.gz')
+    img = np.asanyarray(img_nii.dataobj).transpose([2, 1, 0])  # reverse axis order to match SITK
+    props = {'spacing': img_nii.header.get_zooms()[::-1]}      # reverse axis order to match SITK
     ret = predictor.predict_single_npy_array(img, props, None, None, False)
 ```
 


### PR DESCRIPTION
## Description

This PR clarifies that `predict_single_npy_array` must use SimpleITK axis ordering. _(For other prediction functions, nnUNet's I/O functionality will do the axis re-ordering automatically. But, for `predict_single_npy_array`, axis re-ordering must be done by the caller before passing the array.)_

I've tried to align the docstring of `predict_single_npy_array` with the documentation in `inference/readme.md`, that way if someone jumps straight to the source code (like I did), they won't miss any important info.

I've also added some example code for `nibabel` users that clarifies the necessary steps to use `predict_single_npy_array`, since otherwise we had to figure that out on our own. _(But, perhaps this shouldn't be added, since nnUNet probably wants to encourage use of its own IO functions? Lmk and I can remove that addition if necessary.)

## Related issues/PRs

Fixes https://github.com/MIC-DKFZ/nnUNet/issues/1951.