### PR TITLE
Improving nnUNet inference speed

### DIFF
--- a/nnunetv2/inference/data_iterators.py
+++ b/nnunetv2/inference/data_iterators.py
@@ -38,7 +38,7 @@ def preprocess_fromfiles_save_to_queue(list_of_lists: List[List[str]],
                 seg_onehot = convert_labelmap_to_one_hot(seg[0], label_manager.foreground_labels, data.dtype)
                 data = np.vstack((data, seg_onehot))
 
-            data = torch.from_numpy(data).contiguous().float()
+            data = torch.from_numpy(data).to(dtype=torch.float32, memory_format=torch.contiguous_format)
 
             item = {'data': data, 'data_properties': data_properties,
                     'ofile': output_filenames_truncated[idx] if output_filenames_truncated is not None else None}
@@ -146,9 +146,7 @@ class PreprocessAdapter(DataLoader):
 
     def generate_train_batch(self):
         idx = self.get_indices()[0]
-        files = self._data[idx][0]
-        seg_prev_stage = self._data[idx][1]
-        ofile = self._data[idx][2]
+        files, seg_prev_stage, ofile = self._data[idx][0]
         # if we have a segmentation from the previous stage we have to process it together with the images so that we
         # can crop it appropriately (if needed). Otherwise it would just be resized to the shape of the data after
         # preprocessing and then there might be misalignments
@@ -192,10 +190,7 @@ class PreprocessAdapterFromNpy(DataLoader):
 
     def generate_train_batch(self):
         idx = self.get_indices()[0]
-        image = self._data[idx][0]
-        seg_prev_stage = self._data[idx][1]
-        props = self._data[idx][2]
-        ofname = self._data[idx][3]
+        image, seg_prev_stage, props, ofname = self._data[idx][0]
         # if we have a segmentation from the previous stage we have to process it together with the images so that we
         # can crop it appropriately (if needed). Otherwise it would just be resized to the shape of the data after
         # preprocessing and then there might be misalignments
@@ -238,7 +233,7 @@ def preprocess_fromnpy_save_to_queue(list_of_images: List[np.ndarray],
                 seg_onehot = convert_labelmap_to_one_hot(seg[0], label_manager.foreground_labels, data.dtype)
                 data = np.vstack((data, seg_onehot))
 
-            data = torch.from_numpy(data).contiguous().float()
+            data = torch.from_numpy(data).to(dtype=torch.float32, memory_format=torch.contiguous_format)
 
             item = {'data': data, 'data_properties': list_of_image_properties[idx],
                     'ofile': truncated_ofnames[idx] if truncated_ofnames is not None else None}

--- a/nnunetv2/inference/predict_from_raw_data.py
+++ b/nnunetv2/inference/predict_from_raw_data.py
@@ -55,9 +55,8 @@ class nnUNetPredictor(object):
         self.use_gaussian = use_gaussian
         self.use_mirroring = use_mirroring
         if device.type == 'cuda':
-            # device = torch.device(type='cuda', index=0)  # set the desired GPU with CUDA_VISIBLE_DEVICES!
-            pass
-        if device.type != 'cuda':
+            torch.backends.cudnn.benchmark = True
+        else:
             print(f'perform_everything_on_device=True is only supported for cuda devices! Setting this to False')
             perform_everything_on_device = False
         self.device = device

--- a/nnunetv2/inference/predict_from_raw_data.py
+++ b/nnunetv2/inference/predict_from_raw_data.py
@@ -542,11 +542,12 @@ class nnUNetPredictor(object):
             # x should be 5d for 3d images and 4d for 2d. so the max value of mirror_axes cannot exceed len(x.shape) - 3
             assert max(mirror_axes) <= x.ndim - 3, 'mirror_axes does not match the dimension of the input!'
 
+            mirror_axes = [m + 2 for m in mirror_axes]
             axes_combinations = [
-                c for i in range(len(mirror_axes)) for c in itertools.combinations([m + 2 for m in mirror_axes], i + 1)
+                c for i in range(len(mirror_axes)) for c in itertools.combinations(mirror_axes, i + 1)
             ]
             for axes in axes_combinations:
-                prediction += torch.flip(self.network(torch.flip(x, (*axes,))), (*axes,))
+                prediction += torch.flip(self.network(torch.flip(x, axes)), axes)
             prediction /= (len(axes_combinations) + 1)
         return prediction
 

--- a/nnunetv2/inference/predict_from_raw_data.py
+++ b/nnunetv2/inference/predict_from_raw_data.py
@@ -573,24 +573,27 @@ class nnUNetPredictor(object):
             predicted_logits = torch.zeros((self.label_manager.num_segmentation_heads, *data.shape[1:]),
                                            dtype=torch.half,
                                            device=results_device)
-            n_predictions = torch.zeros(data.shape[1:], dtype=torch.half, device=results_device)
             if self.use_gaussian:
                 gaussian = compute_gaussian(tuple(self.configuration_manager.patch_size), sigma_scale=1. / 8,
                                             value_scaling_factor=10,
                                             device=results_device)
+                n_predictions = torch.zeros(data.shape[1:], dtype=torch.half, device=results_device)
 
-            if self.verbose: print('running prediction')
-            if not self.allow_tqdm and self.verbose: print(f'{len(slicers)} steps')
+            if not self.allow_tqdm and self.verbose:
+                print(f'running prediction: {len(slicers)} steps')
             for sl in tqdm(slicers, disable=not self.allow_tqdm):
                 workon = data[sl][None]
-                workon = workon.to(self.device, non_blocking=False)
+                workon = workon.to(self.device)
 
                 prediction = self._internal_maybe_mirror_and_predict(workon)[0].to(results_device)
 
-                predicted_logits[sl] += (prediction * gaussian if self.use_gaussian else prediction)
-                n_predictions[sl[1:]] += (gaussian if self.use_gaussian else 1)
+                if self.use_gaussian:
+                    prediction *= gaussian
+                    n_predictions[sl[1:]] += gaussian
+                predicted_logits[sl] += prediction
 
-            predicted_logits /= n_predictions
+            if self.use_gaussian:
+                predicted_logits /= n_predictions
             # check for infs
             if torch.any(torch.isinf(predicted_logits)):
                 raise RuntimeError('Encountered inf in predicted array. Aborting... If this problem persists, '
@@ -648,7 +651,7 @@ class nnUNetPredictor(object):
 
             empty_cache(self.device)
             # revert padding
-            predicted_logits = predicted_logits[tuple([slice(None), *slicer_revert_padding[1:]])]
+            predicted_logits = predicted_logits[(slice(None), *slicer_revert_padding[1:])]
         return predicted_logits
 
 

--- a/nnunetv2/inference/sliding_window_prediction.py
+++ b/nnunetv2/inference/sliding_window_prediction.py
@@ -7,7 +7,7 @@ from acvl_utils.cropping_and_padding.padding import pad_nd_image
 from scipy.ndimage import gaussian_filter
 
 
-@lru_cache(maxsize=2)
+@lru_cache(maxsize=None)
 def compute_gaussian(tile_size: Union[Tuple[int, ...], List[int]], sigma_scale: float = 1. / 8,
                      value_scaling_factor: float = 1, dtype=torch.float16, device=torch.device('cuda', 0)) \
         -> torch.Tensor:

--- a/nnunetv2/inference/sliding_window_prediction.py
+++ b/nnunetv2/inference/sliding_window_prediction.py
@@ -7,7 +7,7 @@ from acvl_utils.cropping_and_padding.padding import pad_nd_image
 from scipy.ndimage import gaussian_filter
 
 
-@lru_cache(maxsize=None)
+@lru_cache(maxsize=2)
 def compute_gaussian(tile_size: Union[Tuple[int, ...], List[int]], sigma_scale: float = 1. / 8,
                      value_scaling_factor: float = 1, dtype=torch.float16, device=torch.device('cuda', 0)) \
         -> torch.Tensor:

--- a/nnunetv2/inference/sliding_window_prediction.py
+++ b/nnunetv2/inference/sliding_window_prediction.py
@@ -18,14 +18,12 @@ def compute_gaussian(tile_size: Union[Tuple[int, ...], List[int]], sigma_scale: 
     gaussian_importance_map = gaussian_filter(tmp, sigmas, 0, mode='constant', cval=0)
 
     gaussian_importance_map = torch.from_numpy(gaussian_importance_map)
+    gaussian_importance_map = gaussian_importance_map.to(device=device, dtype=dtype)
 
-    gaussian_importance_map = gaussian_importance_map / torch.max(gaussian_importance_map) * value_scaling_factor
-    gaussian_importance_map = gaussian_importance_map.type(dtype).to(device)
-
+    gaussian_importance_map /= (torch.max(gaussian_importance_map) / value_scaling_factor)
     # gaussian_importance_map cannot be 0, otherwise we may end up with nans!
-    gaussian_importance_map[gaussian_importance_map == 0] = torch.min(
-        gaussian_importance_map[gaussian_importance_map != 0])
-
+    mask = gaussian_importance_map == 0
+    gaussian_importance_map[mask] = torch.min(gaussian_importance_map[~mask])
     return gaussian_importance_map
 
 


### PR DESCRIPTION
Main additions are:
* Using `torch.backends.cudnn.benchmark = True` (used during training, but forgot during inference).
* Replacing `torch.no_grad` context with a single `torch.inference_mode` context.
* Using inplace operations for calculating and using the gaussian. 