### PR TITLE
New feature: adding a parameter to control the number of processes used by the validation dataloader

### DIFF
--- a/nnunetv2/configuration.py
+++ b/nnunetv2/configuration.py
@@ -1,10 +1,6 @@
 import os
 
-from nnunetv2.utilities.default_n_proc_DA import get_allowed_n_proc_DA
-
 default_num_processes = 8 if 'nnUNet_def_n_proc' not in os.environ else int(os.environ['nnUNet_def_n_proc'])
 
 ANISO_THRESHOLD = 3  # determines when a sample is considered anisotropic (3 means that the spacing in the low
 # resolution axis must be 3x as large as the next largest spacing)
-
-default_n_proc_DA = get_allowed_n_proc_DA()

--- a/nnunetv2/experiment_planning/experiment_planners/default_experiment_planner.py
+++ b/nnunetv2/experiment_planning/experiment_planners/default_experiment_planner.py
@@ -15,7 +15,6 @@ from nnunetv2.paths import nnUNet_raw, nnUNet_preprocessed
 from nnunetv2.preprocessing.normalization.map_channel_name_to_normalization import get_normalization_scheme
 from nnunetv2.preprocessing.resampling.default_resampling import resample_data_or_seg_to_shape, compute_new_shape
 from nnunetv2.utilities.dataset_name_id_conversion import maybe_convert_to_dataset_name
-from nnunetv2.utilities.default_n_proc_DA import get_allowed_n_proc_DA
 from nnunetv2.utilities.get_network_from_plans import get_network_from_plans
 from nnunetv2.utilities.json_export import recursive_fix_for_json_export
 from nnunetv2.utilities.utils import get_filenames_of_train_images_and_targets
@@ -100,14 +99,10 @@ class ExperimentPlanner(object):
         """
         Works for PlainConvUNet, ResidualEncoderUNet
         """
-        a = torch.get_num_threads()
-        torch.set_num_threads(get_allowed_n_proc_DA())
-        # print(f'instantiating network, patch size {patch_size}, pool op: {arch_kwargs["strides"]}')
         net = get_network_from_plans(arch_class_name, arch_kwargs, arch_kwargs_req_import, input_channels,
                                      output_channels,
                                      allow_init=False)
         ret = net.compute_conv_feature_map_size(patch_size)
-        torch.set_num_threads(a)
         return ret
 
     def determine_resampling(self, *args, **kwargs):

--- a/nnunetv2/training/nnUNetTrainer/variants/data_augmentation/nnUNetTrainerDAOrd0.py
+++ b/nnunetv2/training/nnUNetTrainer/variants/data_augmentation/nnUNetTrainerDAOrd0.py
@@ -1,9 +1,4 @@
-from batchgenerators.dataloading.single_threaded_augmenter import SingleThreadedAugmenter
-
-from nnunetv2.training.data_augmentation.custom_transforms.limited_length_multithreaded_augmenter import \
-    LimitedLenWrapper
 from nnunetv2.training.nnUNetTrainer.nnUNetTrainer import nnUNetTrainer
-from nnunetv2.utilities.default_n_proc_DA import get_allowed_n_proc_DA
 
 
 class nnUNetTrainerDAOrd0(nnUNetTrainer):
@@ -42,17 +37,7 @@ class nnUNetTrainerDAOrd0(nnUNetTrainer):
 
         dl_tr, dl_val = self.get_plain_dataloaders(initial_patch_size, dim)
 
-        allowed_num_processes = get_allowed_n_proc_DA()
-        if allowed_num_processes == 0:
-            mt_gen_train = SingleThreadedAugmenter(dl_tr, tr_transforms)
-            mt_gen_val = SingleThreadedAugmenter(dl_val, val_transforms)
-        else:
-            mt_gen_train = LimitedLenWrapper(self.num_iterations_per_epoch, dl_tr, tr_transforms,
-                                             allowed_num_processes, 6, None, True, 0.02)
-            mt_gen_val = LimitedLenWrapper(self.num_val_iterations_per_epoch, dl_val, val_transforms,
-                                           max(1, allowed_num_processes // 2), 3, None, True, 0.02)
-
-        return mt_gen_train, mt_gen_val
+        return self.init_dataloaders(dl_tr, tr_transforms, dl_val, val_transforms)
 
 
 class nnUNetTrainer_DASegOrd0(nnUNetTrainer):
@@ -91,17 +76,7 @@ class nnUNetTrainer_DASegOrd0(nnUNetTrainer):
 
         dl_tr, dl_val = self.get_plain_dataloaders(initial_patch_size, dim)
 
-        allowed_num_processes = get_allowed_n_proc_DA()
-        if allowed_num_processes == 0:
-            mt_gen_train = SingleThreadedAugmenter(dl_tr, tr_transforms)
-            mt_gen_val = SingleThreadedAugmenter(dl_val, val_transforms)
-        else:
-            mt_gen_train = LimitedLenWrapper(self.num_iterations_per_epoch, dl_tr, tr_transforms,
-                                             allowed_num_processes, 6, None, True, 0.02)
-            mt_gen_val = LimitedLenWrapper(self.num_val_iterations_per_epoch, dl_val, val_transforms,
-                                           max(1, allowed_num_processes // 2), 3, None, True, 0.02)
-
-        return mt_gen_train, mt_gen_val
+        return self.init_dataloaders(dl_tr, tr_transforms, dl_val, val_transforms)
 
 
 class nnUNetTrainer_DASegOrd0_NoMirroring(nnUNetTrainer):
@@ -144,14 +119,4 @@ class nnUNetTrainer_DASegOrd0_NoMirroring(nnUNetTrainer):
 
         dl_tr, dl_val = self.get_plain_dataloaders(initial_patch_size, dim)
 
-        allowed_num_processes = get_allowed_n_proc_DA()
-        if allowed_num_processes == 0:
-            mt_gen_train = SingleThreadedAugmenter(dl_tr, tr_transforms)
-            mt_gen_val = SingleThreadedAugmenter(dl_val, val_transforms)
-        else:
-            mt_gen_train = LimitedLenWrapper(self.num_iterations_per_epoch, dl_tr, tr_transforms,
-                                             allowed_num_processes, 6, None, True, 0.02)
-            mt_gen_val = LimitedLenWrapper(self.num_val_iterations_per_epoch, dl_val, val_transforms,
-                                           max(1, allowed_num_processes // 2), 3, None, True, 0.02)
-
-        return mt_gen_train, mt_gen_val
+        return self.init_dataloaders(dl_tr, tr_transforms, dl_val, val_transforms)

--- a/nnunetv2/utilities/default_n_proc_DA.py
+++ b/nnunetv2/utilities/default_n_proc_DA.py
@@ -2,6 +2,16 @@ import subprocess
 import os
 
 
+def get_allowed_n_proc_DA_val():
+    """
+    This function is used to set the number of processes used for the validation data loader. When nnUNet_n_proc_DA_val
+    is 0, the validation data is loaded sequentially in the main process.
+    """
+    if 'nnUNet_n_proc_DA_val' in os.environ.keys():
+        return int(os.environ['nnUNet_n_proc_DA_val'])
+    return get_allowed_n_proc_DA() // 2
+
+
 def get_allowed_n_proc_DA():
     """
     This function is used to set the number of processes used on different Systems. It is specific to our cluster


### PR DESCRIPTION
## Motivation

Many nnUNet users try to run it on systems in which the hardware is lacking (there are many users reporting `Some background worker is 6 feet under`). 

Currently, the validation dataloader uses half the number of processes of the training dataloader. A default training with nnUNet uses 1 main process + 12 train dataloader processes + 6 validation dataloader processes, which copy all the main's process allocated memory. 
On systems with modest RAM resources, if there is enough RAM utilization during training, the validation dataloaders' memory (including the validation data that was already loaded) is moved on the swap partition because the validation dataloaders sleep and wait for the end of the training epoch, which makes the start of the validation very slow. 
Reducing the number of dataloader processes (`nnUNet_n_proc_DA`) avoids OOM errors and slowdowns on systems without enough RAM memory that start to use the swap partition.

## New feature

Reducing the number of validation dataloader processes (with the new environment variable `nnUNet_n_proc_DA_val`) enables better resource management and allows for allocating more processes for training by reducing the processes for validation. This solution is especially useful when the default value of `num_val_iterations_per_epoch` is changed from 50 to 10. 



