### PR TITLE
Improving image io

### DIFF
--- a/nnunetv2/imageio/natural_image_reader_writer.py
+++ b/nnunetv2/imageio/natural_image_reader_writer.py
@@ -56,13 +56,13 @@ class NaturalImage2DIO(BaseReaderWriter):
             print('Image files:')
             print(image_fnames)
             raise RuntimeError()
-        return np.vstack(images).astype(np.float32), {'spacing': (999, 1, 1)}
+        return np.vstack(images, dtype=np.float32, casting='unsafe'), {'spacing': (999, 1, 1)}
 
     def read_seg(self, seg_fname: str) -> Tuple[np.ndarray, dict]:
         return self.read_images((seg_fname, ))
 
     def write_seg(self, seg: np.ndarray, output_fname: str, properties: dict) -> None:
-        io.imsave(output_fname, seg[0].astype(np.uint8), check_contrast=False)
+        io.imsave(output_fname, seg[0].astype(np.uint8, copy=False), check_contrast=False)
 
 
 if __name__ == '__main__':

--- a/nnunetv2/imageio/nibabel_reader_writer.py
+++ b/nnunetv2/imageio/nibabel_reader_writer.py
@@ -78,14 +78,13 @@ class NibabelIO(BaseReaderWriter):
             print(image_fnames)
             raise RuntimeError()
 
-        stacked_images = np.vstack(images)
         dict = {
             'nibabel_stuff': {
                 'original_affine': original_affines[0],
             },
             'spacing': spacings_for_nnunet[0]
         }
-        return stacked_images.astype(np.float32), dict
+        return np.vstack(images, dtype=np.float32, casting='unsafe'), dict
 
     def read_seg(self, seg_fname: str) -> Tuple[np.ndarray, dict]:
         return self.read_images((seg_fname, ))
@@ -160,7 +159,6 @@ class NibabelIOWithReorient(BaseReaderWriter):
             print(image_fnames)
             raise RuntimeError()
 
-        stacked_images = np.vstack(images)
         dict = {
             'nibabel_stuff': {
                 'original_affine': original_affines[0],
@@ -168,14 +166,14 @@ class NibabelIOWithReorient(BaseReaderWriter):
             },
             'spacing': spacings_for_nnunet[0]
         }
-        return stacked_images.astype(np.float32), dict
+        return np.vstack(images, dtype=np.float32, casting='unsafe'), dict
 
     def read_seg(self, seg_fname: str) -> Tuple[np.ndarray, dict]:
         return self.read_images((seg_fname, ))
 
     def write_seg(self, seg: np.ndarray, output_fname: str, properties: dict) -> None:
         # revert transpose
-        seg = seg.transpose((2, 1, 0)).astype(np.uint8)
+        seg = seg.transpose((2, 1, 0)).astype(np.uint8, copy=False)
 
         seg_nib = nibabel.Nifti1Image(seg, affine=properties['nibabel_stuff']['reoriented_affine'])
         seg_nib_reoriented = seg_nib.as_reoriented(io_orientation(properties['nibabel_stuff']['original_affine']))

--- a/nnunetv2/imageio/simpleitk_reader_writer.py
+++ b/nnunetv2/imageio/simpleitk_reader_writer.py
@@ -97,7 +97,6 @@ class SimpleITKIO(BaseReaderWriter):
             print(image_fnames)
             raise RuntimeError()
 
-        stacked_images = np.vstack(images)
         dict = {
             'sitk_stuff': {
                 # this saves the sitk geometry information. This part is NOT used by nnU-Net!
@@ -109,7 +108,7 @@ class SimpleITKIO(BaseReaderWriter):
             # are returned x,y,z but spacing is returned z,y,x. Duh.
             'spacing': spacings_for_nnunet[0]
         }
-        return stacked_images.astype(np.float32), dict
+        return np.vstack(images, dtype=np.float32, casting='unsafe'), dict
 
     def read_seg(self, seg_fname: str) -> Tuple[np.ndarray, dict]:
         return self.read_images((seg_fname, ))
@@ -121,7 +120,7 @@ class SimpleITKIO(BaseReaderWriter):
         if output_dimension == 2:
             seg = seg[0]
 
-        itk_image = sitk.GetImageFromArray(seg.astype(np.uint8))
+        itk_image = sitk.GetImageFromArray(seg.astype(np.uint8, copy=False))
         itk_image.SetSpacing(properties['sitk_stuff']['spacing'])
         itk_image.SetOrigin(properties['sitk_stuff']['origin'])
         itk_image.SetDirection(properties['sitk_stuff']['direction'])

--- a/nnunetv2/imageio/tif_reader_writer.py
+++ b/nnunetv2/imageio/tif_reader_writer.py
@@ -66,11 +66,11 @@ class Tiff3DIO(BaseReaderWriter):
             print(image_fnames)
             raise RuntimeError()
 
-        return np.vstack(images).astype(np.float32), {'spacing': spacing}
+        return np.vstack(images, dtype=np.float32, casting='unsafe'), {'spacing': spacing}
 
     def write_seg(self, seg: np.ndarray, output_fname: str, properties: dict) -> None:
         # not ideal but I really have no clue how to set spacing/resolution information properly in tif files haha
-        tifffile.imwrite(output_fname, data=seg.astype(np.uint8), compression='zlib')
+        tifffile.imwrite(output_fname, data=seg.astype(np.uint8, copy=False), compression='zlib')
         file = os.path.basename(output_fname)
         out_dir = os.path.dirname(output_fname)
         ending = file.split('.')[-1]
@@ -97,4 +97,4 @@ class Tiff3DIO(BaseReaderWriter):
             print(f'WARNING no spacing file found for segmentation {seg_fname}\nAssuming spacing (1, 1, 1).')
             spacing = (1, 1, 1)
 
-        return seg.astype(np.float32), {'spacing': spacing}
+        return seg.astype(np.float32, copy=False), {'spacing': spacing}


### PR DESCRIPTION
* reducing the number of allocations when reading images and writing segmentations
* segmentation are casted to np.uint8 only if they are not already np.uint8
* images are stacked directly into a float32 array, without additional casts