### PR TITLE
Fix `ValueError` by removing `[0]` to properly unpack indexed data

### DIFF
--- a/nnunetv2/inference/data_iterators.py
+++ b/nnunetv2/inference/data_iterators.py
@@ -146,7 +146,7 @@ class PreprocessAdapter(DataLoader):
 
     def generate_train_batch(self):
         idx = self.get_indices()[0]
-        files, seg_prev_stage, ofile = self._data[idx][0]
+        files, seg_prev_stage, ofile = self._data[idx]
         # if we have a segmentation from the previous stage we have to process it together with the images so that we
         # can crop it appropriately (if needed). Otherwise it would just be resized to the shape of the data after
         # preprocessing and then there might be misalignments
@@ -190,7 +190,7 @@ class PreprocessAdapterFromNpy(DataLoader):
 
     def generate_train_batch(self):
         idx = self.get_indices()[0]
-        image, seg_prev_stage, props, ofname = self._data[idx][0]
+        image, seg_prev_stage, props, ofname = self._data[idx]
         # if we have a segmentation from the previous stage we have to process it together with the images so that we
         # can crop it appropriately (if needed). Otherwise it would just be resized to the shape of the data after
         # preprocessing and then there might be misalignments


### PR DESCRIPTION
## Description

This fixes a bug introduced in https://github.com/MIC-DKFZ/nnUNet/commit/d87fa5b84e138c536d1f5c2dba7be92856893554:

```python
  File "/__w/spinalcordtoolbox/spinalcordtoolbox/spinalcordtoolbox/deepseg/inference.py", line 228, in segment_nnunet
    pred = predictor.predict_single_npy_array(
  File "/__w/spinalcordtoolbox/spinalcordtoolbox/python/envs/venv_sct/lib/python3.9/site-packages/nnunetv2/inference/predict_from_raw_data.py", line 442, in predict_single_npy_array
    dct = next(ppa)
  File "/__w/spinalcordtoolbox/spinalcordtoolbox/python/envs/venv_sct/lib/python3.9/site-packages/batchgenerators/dataloading/data_loader.py", line 126, in __next__
    return self.generate_train_batch()
  File "/__w/spinalcordtoolbox/spinalcordtoolbox/python/envs/venv_sct/lib/python3.9/site-packages/nnunetv2/inference/data_iterators.py", line 193, in generate_train_batch
    image, seg_prev_stage, props, ofname = self._data[idx][0]
ValueError: not enough values to unpack (expected 4, got 1)
```

By combining the indexes into a single line, I believe the previous commit needed to remove the `[0]` index in order for the indexed data to properly unpack.

## Testing

I tested this PR with our downstream package in https://github.com/spinalcordtoolbox/spinalcordtoolbox/pull/4448#discussion_r1572656454.

The specific command that we run that triggers this issue in the first place can be found [here](https://github.com/spinalcordtoolbox/spinalcordtoolbox/blob/8f2b0e0eb956cbd12d1cabdfbee34e1ca8d99c34/spinalcordtoolbox/deepseg/inference.py#L228-L232). (I'm surprised that this wasn't caught by `nnunetv2`'s test suite! I'm not sure if this issue is specific to `predict_single_npy_array`, but I would presume not?)

## Related issues/PRs

Fixes #2112.