### PR TITLE
add_max_num_epochs

### DIFF
--- a/nnunet/run/run_training.py
+++ b/nnunet/run/run_training.py
@@ -35,6 +35,8 @@ def main():
                         action="store_true")
     parser.add_argument("-c", "--continue_training", help="use this if you want to continue a training",
                         action="store_true")
+    parser.add_argument("-m", "--max_num_epochs", help="use this if you want to train with a different max number of epochs",
+                        required=False, default=1000)
     parser.add_argument("-p", help="plans identifier. Only change this if you created a custom experiment planner",
                         default=default_plans_identifier, required=False)
     parser.add_argument("--use_compressed_data", default=False, action="store_true",
@@ -151,10 +153,13 @@ def main():
         assert issubclass(trainer_class,
                           nnUNetTrainer), "network_trainer was found but is not derived from nnUNetTrainer"
 
-    trainer = trainer_class(plans_file, fold, output_folder=output_folder_name, dataset_directory=dataset_directory,
-                            batch_dice=batch_dice, stage=stage, unpack_data=decompress_data,
+    trainer = trainer_class(plans_file, fold,
+                            output_folder=output_folder_name,dataset_directory=dataset_directory,
+                            batch_dice=batch_dice, stage=stage,
+                            unpack_data=decompress_data,
                             deterministic=deterministic,
-                            fp16=run_mixed_precision)
+                            fp16=run_mixed_precision, 
+                            max_num_epochs=int(args.max_num_epochs))
     if args.disable_saving:
         trainer.save_final_checkpoint = False # whether or not to save the final checkpoint
         trainer.save_best_checkpoint = False  # whether or not to save the best checkpoint according to

--- a/nnunet/training/network_training/nnUNetTrainerV2.py
+++ b/nnunet/training/network_training/nnUNetTrainerV2.py
@@ -42,10 +42,10 @@ class nnUNetTrainerV2(nnUNetTrainer):
     """
 
     def __init__(self, plans_file, fold, output_folder=None, dataset_directory=None, batch_dice=True, stage=None,
-                 unpack_data=True, deterministic=True, fp16=False):
+                 unpack_data=True, deterministic=True, fp16=False, max_num_epochs=1000):
         super().__init__(plans_file, fold, output_folder, dataset_directory, batch_dice, stage, unpack_data,
                          deterministic, fp16)
-        self.max_num_epochs = 1000
+        self.max_num_epochs = max_num_epochs
         self.initial_lr = 1e-2
         self.deep_supervision_scales = None
         self.ds_loss_weights = None


### PR DESCRIPTION
Add an option to set the number of epochs to enable quick test trainings or early stop the training for applications that would take too much time to run 1000 epochs (as now done by default in the codes) and still not converge.