### PR TITLE
Adding sequential inference

### DIFF
--- a/nnunetv2/inference/predict_from_raw_data.py
+++ b/nnunetv2/inference/predict_from_raw_data.py
@@ -882,6 +882,9 @@ def predict_entry_point():
                         help="Use this to set the device the inference should run with. Available options are 'cuda' "
                              "(GPU), 'cpu' (CPU) and 'mps' (Apple M1/M2). Do NOT use this to set which GPU ID! "
                              "Use CUDA_VISIBLE_DEVICES=X nnUNetv2_predict [...] instead!")
+    parser.add_argument('--not_on_device', action='store_true', required=False, default=False,
+                        help="Set this flag to not keep the entire case on device. Recommended for large cases that "
+                             "occupy more VRAM than available")
     parser.add_argument('--disable_progress_bar', action='store_true', required=False, default=False,
                         help='Set this flag to disable progress bar. Recommended for HPC environments (non interactive '
                              'jobs)')
@@ -922,7 +925,7 @@ def predict_entry_point():
     predictor = nnUNetPredictor(tile_step_size=args.step_size,
                                 use_gaussian=True,
                                 use_mirroring=not args.disable_tta,
-                                perform_everything_on_device=True,
+                                perform_everything_on_device=not args.not_on_device,
                                 device=device,
                                 verbose=args.verbose,
                                 verbose_preprocessing=args.verbose,


### PR DESCRIPTION
## Changing the implementation of `predict_single_npy_array` from parallel to sequential.
By default, using `predict_single_npy_array` uses `PreprocessAdapterFromNpy` which creates an additional process for loading the data. This process is not needed because the data was already read into a npy array and is passed to nnUNet. This is also faster because Tensors do not need to be transferred between processes. 
`predict_single_npy_array` does not benefit from parallelism in any situation and the users would benefit more for being able to parallelize themselves `predictor.predict_single_npy_array`.

## Adding support for sequential prediction from files

This allows running `nnUNetv2_predict` with a single process. This allows using less RAM usage per `nnUNetv2_predict` and better parallelization across GPUs when running multiple `nnUNetv2_predict`.

### Previous behavior

To reduce RAM usage when doing prediction you could use `nnUNetv2_predict ... -npp 1 -nps 1`. 
### Current behavior

Now you can use `nnUNetv2_predict ... -npp 0 -nps 0`. It uses less RAM. It is faster when used only for 1 file or parallelized across many GPUs with `-num_parts X`. 
