### PR TITLE
Fix documentation of nibabelIO's supported file types

### DIFF
--- a/nnunetv2/imageio/nibabel_reader_writer.py
+++ b/nnunetv2/imageio/nibabel_reader_writer.py
@@ -31,8 +31,6 @@ class NibabelIO(BaseReaderWriter):
     supported_file_endings = [
         '.nii',
         '.nii.gz',
-        '.nrrd',
-        '.mha'
     ]
 
     def read_images(self, image_fnames: Union[List[str], Tuple[str, ...]]) -> Tuple[np.ndarray, dict]:
@@ -110,8 +108,6 @@ class NibabelIOWithReorient(BaseReaderWriter):
     supported_file_endings = [
         '.nii',
         '.nii.gz',
-        '.nrrd',
-        '.mha'
     ]
 
     def read_images(self, image_fnames: Union[List[str], Tuple[str, ...]]) -> Tuple[np.ndarray, dict]:


### PR DESCRIPTION
With the `NibabelIO` rw classes, .mha and .nrrd files currently cause errors, although they are listed as supported file endings. It seems like nibabel does currently not natively support either of them. [Open issue for nibabel and nrrd](https://github.com/nipy/nibabel/issues/356)

Changes: Remove `.mha` and `.nrrd` from the supported file endings.