### PR TITLE
Implement Argmax Inference Instead of Softmax when 'has_regions' is False

### DIFF
--- a/nnunetv2/inference/export_prediction.py
+++ b/nnunetv2/inference/export_prediction.py
@@ -32,7 +32,7 @@ def convert_predicted_logits_to_segmentation_with_correct_shape(predicted_logits
                                             properties_dict['shape_after_cropping_and_before_resampling'],
                                             current_spacing,
                                             [properties_dict['spacing'][i] for i in plans_manager.transpose_forward])
-    if label_manager.has_regions:
+    if label_manager.has_regions or return_probabilities:
         # return value of resampling_fn_probabilities can be ndarray or Tensor but that does not matter because
         # apply_inference_nonlin will convert to torch
         predicted_probabilities = label_manager.apply_inference_nonlin(predicted_logits)


### PR DESCRIPTION
Issue: I have encountered a memory consumption issue in my Docker setup during inference tasks. Specifically, when the shm-size is set to 30GB, the system can successfully process softmax operations on input tensors of size [24, 724, 435, 435]. However, reducing the shm-size to 15GB leads to the unexpected termination of the Docker container due to insufficient shared memory during softmax computation.

Solution: Implement argmax instead of softmax when the 'has_regions' flag is set to False. This change is intended to address the shared memory (shm-size) constraints within Docker environments. It has been observed that the Docker container can handle the computation effectively, even with the shm-size set to 0, after making the proposed change.