### PR TITLE
Fix dataset order in move plans command

### DIFF
--- a/documentation/pretraining_and_finetuning.md
+++ b/documentation/pretraining_and_finetuning.md
@@ -38,7 +38,7 @@ nnUNetv2_extract_fingerprint -d PRETRAINING_DATASET
 Now we can take the plans from the target dataset and transfer it to the pretraining dataset:
 
 ```bash
-nnUNetv2_move_plans_between_datasets -s PRETRAINING_DATASET -t TARGET_DATASET -sp PRETRAINING_PLANS_IDENTIFIER -tp TARGET_PLANS_IDENTIFIER
+nnUNetv2_move_plans_between_datasets -s TARGET_DATASET -t PRETRAINING_DATASET -sp PRETRAINING_PLANS_IDENTIFIER -tp TARGET_PLANS_IDENTIFIER
 ```
 
 `PRETRAINING_PLANS_IDENTIFIER` is hereby probably nnUNetPlans unless you changed the experiment planner in 


### PR DESCRIPTION
Since the target dataset has been planned before and its plans should be applied to the pretraining dataset, not the other way around, the two dataset arguments should be swapped.

E.g., the following yields the expected behavior with `30` being the pretraining and `31` the target dataset:
```sh
nnUNetv2_move_plans_between_datasets -s 31 -t 30 -sp nnUNetPlans -tp preTrainingPlans
```