### PR TITLE
Fix for issue 291: mmap length is greater than file size

### DIFF
--- a/nnunetv2/training/dataloading/nnunet_dataset.py
+++ b/nnunetv2/training/dataloading/nnunet_dataset.py
@@ -4,14 +4,22 @@ from typing import List
 import numpy as np
 import shutil
 
-from batchgenerators.utilities.file_and_folder_operations import join, load_pickle, isfile
+from batchgenerators.utilities.file_and_folder_operations import (
+    join,
+    load_pickle,
+    isfile,
+)
 from nnunetv2.training.dataloading.utils import get_case_identifiers
 
 
 class nnUNetDataset(object):
-    def __init__(self, folder: str, case_identifiers: List[str] = None,
-                 num_images_properties_loading_threshold: int = 0,
-                 folder_with_segs_from_previous_stage: str = None):
+    def __init__(
+        self,
+        folder: str,
+        case_identifiers: List[str] = None,
+        num_images_properties_loading_threshold: int = 0,
+        folder_with_segs_from_previous_stage: str = None,
+    ):
         """
         This does not actually load the dataset. It merely creates a dictionary where the keys are training case names and
         the values are dictionaries containing the relevant information for that case.
@@ -43,23 +51,28 @@ class nnUNetDataset(object):
         self.dataset = {}
         for c in case_identifiers:
             self.dataset[c] = {}
-            self.dataset[c]['data_file'] = join(folder, f"{c}.npz")
-            self.dataset[c]['properties_file'] = join(folder, f"{c}.pkl")
+            self.dataset[c]["data_file"] = join(folder, f"{c}.npz")
+            self.dataset[c]["properties_file"] = join(folder, f"{c}.pkl")
             if folder_with_segs_from_previous_stage is not None:
-                self.dataset[c]['seg_from_prev_stage_file'] = join(folder_with_segs_from_previous_stage, f"{c}.npz")
+                self.dataset[c]["seg_from_prev_stage_file"] = join(
+                    folder_with_segs_from_previous_stage, f"{c}.npz"
+                )
 
         if len(case_identifiers) <= num_images_properties_loading_threshold:
             for i in self.dataset.keys():
-                self.dataset[i]['properties'] = load_pickle(self.dataset[i]['properties_file'])
+                self.dataset[i]["properties"] = load_pickle(
+                    self.dataset[i]["properties_file"]
+                )
 
-        self.keep_files_open = ('nnUNet_keep_files_open' in os.environ.keys()) and \
-                               (os.environ['nnUNet_keep_files_open'].lower() in ('true', '1', 't'))
+        self.keep_files_open = ("nnUNet_keep_files_open" in os.environ.keys()) and (
+            os.environ["nnUNet_keep_files_open"].lower() in ("true", "1", "t")
+        )
         # print(f'nnUNetDataset.keep_files_open: {self.keep_files_open}')
 
     def __getitem__(self, key):
         ret = {**self.dataset[key]}
-        if 'properties' not in ret.keys():
-            ret['properties'] = load_pickle(ret['properties_file'])
+        if "properties" not in ret.keys():
+            ret["properties"] = load_pickle(ret["properties_file"])
         return ret
 
     def __setitem__(self, key, value):
@@ -79,68 +92,71 @@ class nnUNetDataset(object):
 
     def load_case(self, key):
         entry = self[key]
-        if 'open_data_file' in entry.keys():
-            data = entry['open_data_file']
+        if "open_data_file" in entry.keys():
+            data = entry["open_data_file"]
             # print('using open data file')
-        elif isfile(entry['data_file'][:-4] + ".npy"):
-            data = np.load(entry['data_file'][:-4] + ".npy", 'r')
+        elif isfile(entry["data_file"][:-4] + ".npy"):
+            data = np.load(entry["data_file"][:-4] + ".npy", "r+")
             if self.keep_files_open:
-                self.dataset[key]['open_data_file'] = data
+                self.dataset[key]["open_data_file"] = data
                 # print('saving open data file')
         else:
-            data = np.load(entry['data_file'])['data']
+            data = np.load(entry["data_file"])["data"]
 
-        if 'open_seg_file' in entry.keys():
-            seg = entry['open_seg_file']
+        if "open_seg_file" in entry.keys():
+            seg = entry["open_seg_file"]
             # print('using open data file')
-        elif isfile(entry['data_file'][:-4] + "_seg.npy"):
-            seg = np.load(entry['data_file'][:-4] + "_seg.npy", 'r')
+        elif isfile(entry["data_file"][:-4] + "_seg.npy"):
+            seg = np.load(entry["data_file"][:-4] + "_seg.npy", "r+")
             if self.keep_files_open:
-                self.dataset[key]['open_seg_file'] = seg
+                self.dataset[key]["open_seg_file"] = seg
                 # print('saving open seg file')
         else:
-            seg = np.load(entry['data_file'])['seg']
+            seg = np.load(entry["data_file"])["seg"]
 
-        if 'seg_from_prev_stage_file' in entry.keys():
-            if isfile(entry['seg_from_prev_stage_file'][:-4] + ".npy"):
-                seg_prev = np.load(entry['seg_from_prev_stage_file'][:-4] + ".npy", 'r')
+        if "seg_from_prev_stage_file" in entry.keys():
+            if isfile(entry["seg_from_prev_stage_file"][:-4] + ".npy"):
+                seg_prev = np.load(
+                    entry["seg_from_prev_stage_file"][:-4] + ".npy", "r+"
+                )
             else:
-                seg_prev = np.load(entry['seg_from_prev_stage_file'])['seg']
+                seg_prev = np.load(entry["seg_from_prev_stage_file"])["seg"]
             seg = np.vstack((seg, seg_prev[None]))
 
-        return data, seg, entry['properties']
+        return data, seg, entry["properties"]
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     # this is a mini test. Todo: We can move this to tests in the future (requires simulated dataset)
 
-    folder = '/media/fabian/data/nnUNet_preprocessed/Dataset003_Liver/3d_lowres'
-    ds = nnUNetDataset(folder, num_images_properties_loading_threshold=0) # this should not load the properties!
+    folder = "/media/fabian/data/nnUNet_preprocessed/Dataset003_Liver/3d_lowres"
+    ds = nnUNetDataset(
+        folder, num_images_properties_loading_threshold=0
+    )  # this should not load the properties!
     # this SHOULD HAVE the properties
-    ks = ds['liver_0'].keys()
-    assert 'properties' in ks
+    ks = ds["liver_0"].keys()
+    assert "properties" in ks
     # amazing. I am the best.
 
     # this should have the properties
     ds = nnUNetDataset(folder, num_images_properties_loading_threshold=1000)
     # now rename the properties file so that it does not exist anymore
-    shutil.move(join(folder, 'liver_0.pkl'), join(folder, 'liver_XXX.pkl'))
+    shutil.move(join(folder, "liver_0.pkl"), join(folder, "liver_XXX.pkl"))
     # now we should still be able to access the properties because they have already been loaded
-    ks = ds['liver_0'].keys()
-    assert 'properties' in ks
+    ks = ds["liver_0"].keys()
+    assert "properties" in ks
     # move file back
-    shutil.move(join(folder, 'liver_XXX.pkl'), join(folder, 'liver_0.pkl'))
+    shutil.move(join(folder, "liver_XXX.pkl"), join(folder, "liver_0.pkl"))
 
     # this should not have the properties
     ds = nnUNetDataset(folder, num_images_properties_loading_threshold=0)
     # now rename the properties file so that it does not exist anymore
-    shutil.move(join(folder, 'liver_0.pkl'), join(folder, 'liver_XXX.pkl'))
+    shutil.move(join(folder, "liver_0.pkl"), join(folder, "liver_XXX.pkl"))
     # now this should crash
     try:
-        ks = ds['liver_0'].keys()
-        raise RuntimeError('we should not have come here')
+        ks = ds["liver_0"].keys()
+        raise RuntimeError("we should not have come here")
     except FileNotFoundError:
-        print('all good')
+        print("all good")
         # move file back
-        shutil.move(join(folder, 'liver_XXX.pkl'), join(folder, 'liver_0.pkl'))
-
+        shutil.move(join(folder, "liver_XXX.pkl"), join(folder, "liver_0.pkl"))


### PR DESCRIPTION
Dear @FabianIsensee  and others: It appears there are at least two of us who have been able to work around the issue in https://github.com/MIC-DKFZ/nnUNet/issues/291 with the simple fix of changing calls to:

np.load(... , 'r')

to 

np.load(... , 'r+')

This PR should ideally then not affect any other parts of the codebase, hence being safe to merge. Should you have any questions about this, please let me know! 

Amith