### PR TITLE
Fix `deep_supervision` parameter doesn't work in `nnunetv2.utilities.get_network_from_plans`

### DIFF
--- a/nnunetv2/training/nnUNetTrainer/nnUNetTrainer.py
+++ b/nnunetv2/training/nnUNetTrainer/nnUNetTrainer.py
@@ -907,9 +907,6 @@ class nnUNetTrainer(object):
 
         maybe_mkdir_p(self.output_folder)
 
-        # make sure deep supervision is on in the network
-        self.set_deep_supervision_enabled(self.enable_deep_supervision)
-
         self.print_plans()
         empty_cache(self.device)
 

--- a/nnunetv2/utilities/get_network_from_plans.py
+++ b/nnunetv2/utilities/get_network_from_plans.py
@@ -1,6 +1,7 @@
 import pydoc
 import warnings
 from typing import Union
+from copy import deepcopy
 
 from nnunetv2.utilities.find_class_by_name import recursive_find_python_class
 from batchgenerators.utilities.file_and_folder_operations import join
@@ -9,7 +10,7 @@ from batchgenerators.utilities.file_and_folder_operations import join
 def get_network_from_plans(arch_class_name, arch_kwargs, arch_kwargs_req_import, input_channels, output_channels,
                            allow_init=True, deep_supervision: Union[bool, None] = None):
     network_class = arch_class_name
-    architecture_kwargs = dict(**arch_kwargs)
+    architecture_kwargs = deepcopy(arch_kwargs)
     for ri in arch_kwargs_req_import:
         if architecture_kwargs[ri] is not None:
             architecture_kwargs[ri] = pydoc.locate(architecture_kwargs[ri])
@@ -28,8 +29,8 @@ def get_network_from_plans(arch_class_name, arch_kwargs, arch_kwargs_req_import,
         else:
             raise ImportError('Network class could not be found, please check/correct your plans file')
 
-    if deep_supervision is not None and 'deep_supervision' not in arch_kwargs.keys():
-        arch_kwargs['deep_supervision'] = deep_supervision
+    if deep_supervision is not None and 'deep_supervision' not in architecture_kwargs.keys():
+        architecture_kwargs['deep_supervision'] = deep_supervision
 
     network = nw_class(
         input_channels=input_channels,
@@ -41,3 +42,35 @@ def get_network_from_plans(arch_class_name, arch_kwargs, arch_kwargs_req_import,
         network.apply(network.initialize)
 
     return network
+
+if __name__ == "__main__":
+    import torch
+
+    model = get_network_from_plans(
+        arch_class_name="dynamic_network_architectures.architectures.unet.ResidualEncoderUNet",
+        arch_kwargs={
+            "n_stages": 7,
+            "features_per_stage": [32, 64, 128, 256, 512, 512, 512],
+            "conv_op": "torch.nn.modules.conv.Conv2d",
+            "kernel_sizes": [[3, 3], [3, 3], [3, 3], [3, 3], [3, 3], [3, 3], [3, 3]],
+            "strides": [[1, 1], [2, 2], [2, 2], [2, 2], [2, 2], [2, 2], [2, 2]],
+            "n_blocks_per_stage": [1, 3, 4, 6, 6, 6, 6],
+            "n_conv_per_stage_decoder": [1, 1, 1, 1, 1, 1],
+            "conv_bias": True,
+            "norm_op": "torch.nn.modules.instancenorm.InstanceNorm2d",
+            "norm_op_kwargs": {"eps": 1e-05, "affine": True},
+            "dropout_op": None,
+            "dropout_op_kwargs": None,
+            "nonlin": "torch.nn.LeakyReLU",
+            "nonlin_kwargs": {"inplace": True},
+        },
+        arch_kwargs_req_import=["conv_op", "norm_op", "dropout_op", "nonlin"],
+        input_channels=1,
+        output_channels=4,
+        allow_init=True,
+        deep_supervision=True,
+    )
+    data = torch.rand((8, 1, 256, 256))
+    target = torch.rand(size=(8, 1, 256, 256))
+    output = model(data)
+    assert isinstance(output, list), "deep-supervisison doesn't work"


### PR DESCRIPTION
- Bug: 
`nnunetv2.utilities.get_network_from_plans` has an optional parameter: `deep_supervision`, but it doesn't work.

- Fix: 

```python
...
    if deep_supervision is not None and 'deep_supervision' not in arch_kwargs.keys():
        arch_kwargs['deep_supervision'] = deep_supervision
```

to 

```python
...
    if deep_supervision is not None and 'deep_supervision' not in architecture_kwargs.keys():
        architecture_kwargs['deep_supervision'] = deep_supervision

```

- An example for this function:
```python
if __name__ == "__main__":
    import torch

    model = get_network_from_plans(
        arch_class_name="dynamic_network_architectures.architectures.unet.ResidualEncoderUNet",
        arch_kwargs={
            "n_stages": 7,
            "features_per_stage": [32, 64, 128, 256, 512, 512, 512],
            "conv_op": "torch.nn.modules.conv.Conv2d",
            "kernel_sizes": [[3, 3], [3, 3], [3, 3], [3, 3], [3, 3], [3, 3], [3, 3]],
            "strides": [[1, 1], [2, 2], [2, 2], [2, 2], [2, 2], [2, 2], [2, 2]],
            "n_blocks_per_stage": [1, 3, 4, 6, 6, 6, 6],
            "n_conv_per_stage_decoder": [1, 1, 1, 1, 1, 1],
            "conv_bias": True,
            "norm_op": "torch.nn.modules.instancenorm.InstanceNorm2d",
            "norm_op_kwargs": {"eps": 1e-05, "affine": True},
            "dropout_op": None,
            "dropout_op_kwargs": None,
            "nonlin": "torch.nn.LeakyReLU",
            "nonlin_kwargs": {"inplace": True},
        },
        arch_kwargs_req_import=["conv_op", "norm_op", "dropout_op", "nonlin"],
        input_channels=1,
        output_channels=4,
        allow_init=True,
        deep_supervision=True,
    )
    data = torch.rand((8, 1, 256, 256))
    target = torch.rand(size=(8, 1, 256, 256))
    output = model(data)
    assert isinstance(output, list), "deep-supervisison doesn't work"
```

- And remove a redundant line in `nnunetv2.training.nnUNetTrainer.nnUNetTrainer.py`
```python
...
        # make sure deep supervision is on in the network
        self.set_deep_supervision_enabled(self.enable_deep_supervision)
```
This may be added due to the bug as mentioned above.