### PR TITLE
Fix typo in set_environment_variables.md

### DIFF
--- a/documentation/set_environment_variables.md
+++ b/documentation/set_environment_variables.md
@@ -75,4 +75,4 @@ Printing in Windows works differently depending on the environment you are in:
 
 PowerShell: `echo $Env:[variable_name]`
 
-Command Prompt: `echo %[variable_name]%`
+Command Prompt: `echo %variable_name%`


### PR DESCRIPTION
Fix typo in command prompt variable syntax: use `echo %variable_name%` instead of `echo %[variable_name]%`