### PR TITLE
Minor fixes to paths.md declaration in docs

### DIFF
--- a/documentation/setting_up_paths.md
+++ b/documentation/setting_up_paths.md
@@ -35,4 +35,5 @@ throughput (such as a nvme SSD (PCIe gen 3 is sufficient)).
 is where it will save them.
 
 ### How to set environment variables
+
 See [here](set_environment_variables.md).

--- a/nnunetv2/paths.py
+++ b/nnunetv2/paths.py
@@ -15,7 +15,7 @@
 import os
 
 """
-PLEASE READ paths.md FOR INFORMATION TO HOW TO SET THIS UP
+PLEASE READ documentation/setting_up_paths.md FOR INFORMATION TO HOW TO SET THIS UP
 """
 
 nnUNet_raw = os.environ.get('nnUNet_raw')


### PR DESCRIPTION
`nnunetv2/paths.py` was referencing incorrect doc MD file, pointed that to correct one. 