### PR TITLE
Fast inference for large files with several classes #2540

### DIFF
--- a/nnunetv2/inference/predict_from_raw_data.py
+++ b/nnunetv2/inference/predict_from_raw_data.py
@@ -63,7 +63,7 @@ class nnUNetPredictor(object):
         self.perform_everything_on_device = perform_everything_on_device
 
     def initialize_from_trained_model_folder(self, model_training_output_dir: str,
-                                             use_folds: Union[Tuple[Union[int, str]], None],
+                                             use_folds: Union[Tuple[Union[int, str], ...], None],
                                              checkpoint_name: str = 'checkpoint_final.pth'):
         """
         This is used when making predictions with a trained model


### PR DESCRIPTION
When doing inference on large files with large number of classes the following code section blocks the code for up too 600 seconds:

```
            for c in range(data.shape[0]):
                reshaped_final[c] = resize_fn(data[c], new_shape, order, **kwargs)
```
in `preprocessing.resampling.default_resampling.py` and func: `resample_data_or_seg`.
If someone does not need the probabilities they can skip this section by only sending the segmentation array which is very fast.




Solving issue #2540 