### PR TITLE
adding focal loss, distance map dice loss, loading distance maps

### DIFF
--- a/nnunetv2/evaluation/evaluate_predictions.py
+++ b/nnunetv2/evaluation/evaluate_predictions.py
@@ -251,12 +251,13 @@ def evaluate_simple_entry_point():
 
 
 if __name__ == '__main__':
-    folder_ref = '/media/fabian/data/nnUNet_raw/Dataset004_Hippocampus/labelsTr'
-    folder_pred = '/home/fabian/results/nnUNet_remake/Dataset004_Hippocampus/nnUNetModule__nnUNetPlans__3d_fullres/fold_0/validation'
-    output_file = '/home/fabian/results/nnUNet_remake/Dataset004_Hippocampus/nnUNetModule__nnUNetPlans__3d_fullres/fold_0/validation/summary.json'
+    folder_ref = '/home/andyding/tbone-seg-nnunetv2/00_nnUNetv2_baseline_retrain/nnUNet_raw/Dataset101_TemporalBone/labelsTs'
+    folder_pred = '/home/andyding/tbone-seg-nnunetv2/00_nnUNetv2_baseline_retrain/nnUNet_trained_models/Dataset101_TemporalBone/nnUNetTrainer_300epochs__nnUNetPlans__3d_fullres/test_results/postprocessed'
+    output_file = '/home/andyding/tbone-seg-nnunetv2/00_nnUNetv2_baseline_retrain/nnUNet_trained_models/Dataset101_TemporalBone/nnUNetTrainer_300epochs__nnUNetPlans__3d_fullres/test_results/postprocessed/summary.json'
+
     image_reader_writer = SimpleITKIO()
     file_ending = '.nii.gz'
-    regions = labels_to_list_of_regions([1, 2])
+    regions = labels_to_list_of_regions(list(range(17)))
     ignore_label = None
     num_processes = 12
     compute_metrics_on_folder(folder_ref, folder_pred, output_file, image_reader_writer, file_ending, regions, ignore_label,

--- a/nnunetv2/experiment_planning/experiment_planners/distance_transform_experiment_planner.py
+++ b/nnunetv2/experiment_planning/experiment_planners/distance_transform_experiment_planner.py
@@ -1,0 +1,156 @@
+import shutil
+from copy import deepcopy
+from typing import List, Union, Tuple
+import argparse
+
+import numpy as np
+import torch
+from batchgenerators.utilities.file_and_folder_operations import load_json, join, save_json, isfile, maybe_mkdir_p
+from nnunetv2.configuration import ANISO_THRESHOLD
+from nnunetv2.experiment_planning.experiment_planners.network_topology import get_pool_and_conv_props
+from nnunetv2.imageio.reader_writer_registry import determine_reader_writer_from_dataset_json
+from nnunetv2.paths import nnUNet_raw, nnUNet_preprocessed
+from nnunetv2.preprocessing.normalization.map_channel_name_to_normalization import get_normalization_scheme
+from nnunetv2.preprocessing.resampling.default_resampling import resample_data_or_seg_to_shape, compute_new_shape
+from nnunetv2.utilities.dataset_name_id_conversion import maybe_convert_to_dataset_name
+from nnunetv2.utilities.default_n_proc_DA import get_allowed_n_proc_DA
+from nnunetv2.utilities.get_network_from_plans import get_network_from_plans
+from nnunetv2.utilities.json_export import recursive_fix_for_json_export
+from nnunetv2.utilities.utils import get_filenames_of_train_images_and_targets
+from nnunetv2.experiment_planning.experiment_planners.default_experiment_planner import ExperimentPlanner
+
+class DistanceTransformExperimentPlanner(ExperimentPlanner):
+    def __init__(self, dataset_name_or_id: Union[str, int],
+                 gpu_memory_target_in_gb: float = 8,
+                 preprocessor_name: str = 'DefaultPreprocessor', plans_name: str = 'DistanceTransformPlans',
+                 overwrite_target_spacing: Union[List[float], Tuple[float, ...]] = None,
+                 suppress_transpose: bool = False):
+        super().__init__(dataset_name_or_id, gpu_memory_target_in_gb, preprocessor_name, plans_name, overwrite_target_spacing, suppress_transpose)
+        
+        # Custom properties for distance maps
+        self.distance_maps_dir = join(nnUNet_preprocessed, self.dataset_name, 'distance_transforms')
+
+    def plan_experiment(self):
+        """
+        Extend the default plan_experiment function to incorporate distance maps into the plans.
+        """
+        _tmp = {}
+
+        # Get transpose
+        transpose_forward, transpose_backward = self.determine_transpose()
+
+        # Get fullres spacing and transpose it
+        fullres_spacing = self.determine_fullres_target_spacing()
+        fullres_spacing_transposed = fullres_spacing[transpose_forward]
+
+        # Get transposed new median shape (what we would have after resampling)
+        new_shapes = [compute_new_shape(j, i, fullres_spacing) for i, j in
+                      zip(self.dataset_fingerprint['spacings'], self.dataset_fingerprint['shapes_after_crop'])]
+        new_median_shape = np.median(new_shapes, 0)
+        new_median_shape_transposed = new_median_shape[transpose_forward]
+
+        approximate_n_voxels_dataset = float(np.prod(new_median_shape_transposed, dtype=np.float64) *
+                                             self.dataset_json['numTraining'])
+        # Only run 3d if this is a 3d dataset
+        if new_median_shape_transposed[0] != 1:
+            plan_3d_fullres = self.get_plans_for_configuration(fullres_spacing_transposed,
+                                                               new_median_shape_transposed,
+                                                               self.generate_data_identifier('3d_fullres'),
+                                                               approximate_n_voxels_dataset, _tmp)
+            plan_3d_fullres['distance_maps_dir'] = self.distance_maps_dir  # Add distance maps directory to the plans
+            plan_3d_fullres['batch_dice'] = True
+        else:
+            plan_3d_fullres = None
+
+        # 2D configuration
+        plan_2d = self.get_plans_for_configuration(fullres_spacing_transposed[1:],
+                                                   new_median_shape_transposed[1:],
+                                                   self.generate_data_identifier('2d'), approximate_n_voxels_dataset,
+                                                   _tmp)
+        plan_2d['distance_maps_dir'] = self.distance_maps_dir  # Add distance maps directory to the plans
+        plan_2d['batch_dice'] = True
+
+        print('2D U-Net configuration:')
+        print(plan_2d)
+        print()
+
+        # Median spacing and shape, just for reference when printing the plans
+        median_spacing = np.median(self.dataset_fingerprint['spacings'], 0)[transpose_forward]
+        median_shape = np.median(self.dataset_fingerprint['shapes_after_crop'], 0)[transpose_forward]
+
+        # Instead of writing all that into the plans we just copy the original file. More files, but less crowded
+        # per file.
+        shutil.copy(join(self.raw_dataset_folder, 'dataset.json'),
+                    join(nnUNet_preprocessed, self.dataset_name, 'dataset.json'))
+
+        # JSON serialization adjustment
+        plans = {
+            'dataset_name': self.dataset_name,
+            'plans_name': self.plans_identifier,
+            'original_median_spacing_after_transp': [float(i) for i in median_spacing],
+            'original_median_shape_after_transp': [int(round(i)) for i in median_shape],
+            'image_reader_writer': self.determine_reader_writer().__name__,
+            'transpose_forward': [int(i) for i in transpose_forward],
+            'transpose_backward': [int(i) for i in transpose_backward],
+            'configurations': {'2d': plan_2d},
+            'experiment_planner_used': self.__class__.__name__,
+            'label_manager': 'LabelManager',
+            'foreground_intensity_properties_per_channel': self.dataset_fingerprint['foreground_intensity_properties_per_channel']
+        }
+
+        if plan_3d_fullres is not None:
+            plans['configurations']['3d_fullres'] = plan_3d_fullres
+            print('3D fullres U-Net configuration:')
+            print(plan_3d_fullres)
+            print()
+
+        self.plans = plans
+        self.save_plans(plans)
+        return plans
+
+    def save_plans(self, plans):
+        recursive_fix_for_json_export(plans)
+
+        plans_file = join(nnUNet_preprocessed, self.dataset_name, self.plans_identifier + '.json')
+
+        # Avoid overwriting existing custom configurations every time this is executed.
+        if isfile(plans_file):
+            old_plans = load_json(plans_file)
+            old_configurations = old_plans['configurations']
+            for c in plans['configurations'].keys():
+                if c in old_configurations.keys():
+                    del (old_configurations[c])
+            plans['configurations'].update(old_configurations)
+
+        maybe_mkdir_p(join(nnUNet_preprocessed, self.dataset_name))
+        save_json(plans, plans_file, sort_keys=False)
+        print(f"Plans were saved to {join(nnUNet_preprocessed, self.dataset_name, self.plans_identifier + '.json')}")
+
+def test_distance_transform_experiment_planner(dataset_name_or_id=101):
+    # Create an instance of the planner
+    planner = DistanceTransformExperimentPlanner(dataset_name_or_id=dataset_name_or_id,
+                                                 gpu_memory_target_in_gb=8)
+    
+    # Run the planner
+    try:
+        plans = planner.plan_experiment()
+        print("Experiment planner executed successfully.")
+        
+        # Check if the plans have the distance_maps_dir property in their configurations
+        assert plans['configurations'] is not None, "Configurations are missing from the plans."
+        assert '2d' in plans['configurations'], "2D plan configuration is missing."
+        assert 'distance_maps_dir' in plans['configurations']['2d'], "Distance maps directory is missing in 2D configuration."
+        
+        if '3d_fullres' in plans['configurations']:
+            assert 'distance_maps_dir' in plans['configurations']['3d_fullres'], "Distance maps directory is missing in 3D fullres configuration."
+        
+    except Exception as e:
+        print(f"Experiment planner test failed: {e}")
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Test the DistanceTransformExperimentPlanner.")
+    parser.add_argument('-d', '--dataset_id', type=str, default="test_dataset", help='Dataset name or ID to be used for testing.')
+    args = parser.parse_args()
+
+    # Run the test function with the provided dataset ID
+    test_distance_transform_experiment_planner(dataset_name_or_id=args.dataset_id)

--- a/nnunetv2/training/data_augmentation/custom_transforms/distance_map_augmentation.py
+++ b/nnunetv2/training/data_augmentation/custom_transforms/distance_map_augmentation.py
@@ -1,0 +1,98 @@
+import inspect
+import multiprocessing
+import os
+import shutil
+import sys
+import warnings
+from copy import deepcopy
+from datetime import datetime
+from time import time, sleep
+from typing import Tuple, Union, List
+
+import abc
+import numpy as np
+import torch
+from batchgenerators.dataloading.multi_threaded_augmenter import MultiThreadedAugmenter
+from batchgenerators.dataloading.nondet_multi_threaded_augmenter import NonDetMultiThreadedAugmenter
+from batchgenerators.dataloading.single_threaded_augmenter import SingleThreadedAugmenter
+from batchgenerators.utilities.file_and_folder_operations import join, load_json, isfile, save_json, maybe_mkdir_p
+from batchgeneratorsv2.helpers.scalar_type import RandomScalar
+from batchgeneratorsv2.transforms.base.basic_transform import BasicTransform
+from batchgeneratorsv2.transforms.intensity.brightness import MultiplicativeBrightnessTransform
+from batchgeneratorsv2.transforms.intensity.contrast import ContrastTransform, BGContrast
+from batchgeneratorsv2.transforms.intensity.gamma import GammaTransform
+from batchgeneratorsv2.transforms.intensity.gaussian_noise import GaussianNoiseTransform
+from batchgeneratorsv2.transforms.nnunet.random_binary_operator import ApplyRandomBinaryOperatorTransform
+from batchgeneratorsv2.transforms.nnunet.remove_connected_components import \
+    RemoveRandomConnectedComponentFromOneHotEncodingTransform
+from batchgeneratorsv2.transforms.nnunet.seg_to_onehot import MoveSegAsOneHotToDataTransform
+from batchgeneratorsv2.transforms.noise.gaussian_blur import GaussianBlurTransform
+from batchgeneratorsv2.transforms.spatial.low_resolution import SimulateLowResolutionTransform
+from batchgeneratorsv2.transforms.spatial.mirroring import MirrorTransform
+from batchgeneratorsv2.transforms.spatial.spatial import SpatialTransform
+from batchgeneratorsv2.transforms.utils.compose import ComposeTransforms
+from batchgeneratorsv2.transforms.utils.deep_supervision_downsampling import DownsampleSegForDSTransform
+from batchgeneratorsv2.transforms.utils.nnunet_masking import MaskImageTransform
+from batchgeneratorsv2.transforms.utils.pseudo2d import Convert3DTo2DTransform, Convert2DTo3DTransform
+from batchgeneratorsv2.transforms.utils.random import RandomTransform
+from batchgeneratorsv2.transforms.utils.remove_label import RemoveLabelTansform
+from batchgeneratorsv2.transforms.utils.seg_to_regions import ConvertSegmentationToRegionsTransform
+from torch import autocast, nn
+from torch import distributed as dist
+from torch._dynamo import OptimizedModule
+from torch.cuda import device_count
+from torch.cuda.amp import GradScaler
+from torch.nn.parallel import DistributedDataParallel as DDP
+from torch.nn.functional import interpolate
+
+class Convert3DTo2DDistTransform(Convert3DTo2DTransform):
+    def apply(self, data_dict, **params):
+        if 'dist_map' in data_dict.keys():
+            data_dict['nchannels_dist_map'] = deepcopy(data_dict['dist_map']).shape[0]
+        return super().apply(data_dict, **params)
+
+    def _apply_to_dist_map(self, dist_map: torch.Tensor, **params) -> torch.Tensor:
+        return self._apply_to_image(dist_map, **params)
+
+class Convert2DTo3DDistTransform(Convert2DTo3DTransform):
+    def get_parameters(self, **data_dict) -> dict:
+        return {i: data_dict[i] for i in
+                ['nchannels_img', 'nchannels_seg', 'nchannels_regr_trg', 'nchannels_dist_map']
+                if i in data_dict.keys()}
+
+    def apply(self, data_dict, **params):
+        if 'nchannels_dist_map' in data_dict.keys():
+            del data_dict['nchannels_dist_map']
+        return super().apply(data_dict, **params)
+
+class SpatialDistTransform(SpatialTransform):
+    def _apply_to_dist_map(self, dist_map, **params) -> torch.Tensor:
+        return self._apply_to_image(dist_map, **params)
+
+class MirrorDistTransform(MirrorTransform):
+    def _apply_to_dist_map(self, dist_map: torch.Tensor, **params) -> torch.Tensor:
+        if len(params['axes']) == 0:
+            return dist_map
+        axes = [i + 1 for i in params['axes']]
+        return torch.flip(dist_map, axes)
+
+class DownsampleSegForDSDistTransform(DownsampleSegForDSTransform):
+    def _apply_to_dist_map(self, dist_map: torch.Tensor, **params) -> List[torch.Tensor]:
+        results = []
+        for s in self.ds_scales:
+            if not isinstance(s, (tuple, list)):
+                s = [s] * (dist_map.ndim - 1)
+            else:
+                assert len(s) == dist_map.ndim - 1
+
+            if all([i == 1 for i in s]):
+                results.append(dist_map)
+            else:
+                new_shape = [round(i * j) for i, j in zip(dist_map.shape[1:], s)]
+                dtype = dist_map.dtype
+                # interpolate is not defined for short etc
+                results.append(interpolate(dist_map[None].float(), new_shape, mode='bilinear')[0].to(dtype))
+        return results
+
+if __name__ == '__main__':
+    pass

--- a/nnunetv2/training/dataloading/__init__.py
+++ b/nnunetv2/training/dataloading/__init__.py
@@ -1,0 +1,1 @@
+from .distance_transform_dataset import DistanceTransformDataset

--- a/nnunetv2/training/dataloading/data_loader_3d_dist.py
+++ b/nnunetv2/training/dataloading/data_loader_3d_dist.py
@@ -1,0 +1,215 @@
+import numpy as np
+import torch
+from threadpoolctl import threadpool_limits
+from typing import Union, Tuple
+
+from batchgenerators.dataloading.data_loader import DataLoader
+from batchgenerators.utilities.file_and_folder_operations import *
+from nnunetv2.training.dataloading.nnunet_dataset import nnUNetDataset
+from nnunetv2.utilities.label_handling.label_handling import LabelManager
+from nnunetv2.training.dataloading.data_loader_3d import nnUNetDataLoader3D
+
+class nnUNetDataLoader3DDist(DataLoader):
+    def __init__(self,
+                 data: nnUNetDataset,
+                 batch_size: int,
+                 patch_size: Union[List[int], Tuple[int, ...], np.ndarray],
+                 final_patch_size: Union[List[int], Tuple[int, ...], np.ndarray],
+                 label_manager: LabelManager,
+                 oversample_foreground_percent: float = 0.0,
+                 sampling_probabilities: Union[List[int], Tuple[int, ...], np.ndarray] = None,
+                 pad_sides: Union[List[int], Tuple[int, ...], np.ndarray] = None,
+                 probabilistic_oversampling: bool = False,
+                 transforms=None):
+        super().__init__(data, batch_size, 1, None, True, False, True, sampling_probabilities)
+        self.indices = list(data.keys())
+
+        self.oversample_foreground_percent = oversample_foreground_percent
+        self.final_patch_size = final_patch_size
+        self.patch_size = patch_size
+        self.list_of_keys = list(self._data.keys())
+        # need_to_pad denotes by how much we need to pad the data so that if we sample a patch of size final_patch_size
+        # (which is what the network will get) these patches will also cover the border of the images
+        self.need_to_pad = (np.array(patch_size) - np.array(final_patch_size)).astype(int)
+        if pad_sides is not None:
+            if not isinstance(pad_sides, np.ndarray):
+                pad_sides = np.array(pad_sides)
+            self.need_to_pad += pad_sides
+        self.num_channels = None
+        self.pad_sides = pad_sides
+        self.data_shape, self.seg_shape, self.dist_map_shape = self.determine_shapes()
+        self.sampling_probabilities = sampling_probabilities
+        self.annotated_classes_key = tuple(label_manager.all_labels)
+        self.has_ignore = label_manager.has_ignore_label
+        self.get_do_oversample = self._oversample_last_XX_percent if not probabilistic_oversampling \
+            else self._probabilistic_oversampling
+        self.transforms = transforms
+
+    def _oversample_last_XX_percent(self, sample_idx: int) -> bool:
+        """
+        determines whether sample sample_idx in a minibatch needs to be guaranteed foreground
+        """
+        return not sample_idx < round(self.batch_size * (1 - self.oversample_foreground_percent))
+
+    def _probabilistic_oversampling(self, sample_idx: int) -> bool:
+        # print('YEAH BOIIIIII')
+        return np.random.uniform() < self.oversample_foreground_percent
+    
+    def determine_shapes(self):
+        # load one case
+        data, seg, dist_map, properties = self._data.load_case(self.indices[0])
+        num_color_channels = data.shape[0]
+
+        data_shape = (self.batch_size, num_color_channels, *self.patch_size)
+        seg_shape = (self.batch_size, seg.shape[0], *self.patch_size)
+        dist_map_shape = (self.batch_size, dist_map.shape[0], *self.patch_size)
+
+        return data_shape, seg_shape, dist_map_shape
+
+    def get_bbox(self, data_shape: np.ndarray, force_fg: bool, class_locations: Union[dict, None],
+                 overwrite_class: Union[int, Tuple[int, ...]] = None, verbose: bool = False):
+        # in dataloader 2d we need to select the slice prior to this and also modify the class_locations to only have
+        # locations for the given slice
+        need_to_pad = self.need_to_pad.copy()
+        dim = len(data_shape)
+
+        for d in range(dim):
+            # if case_all_data.shape + need_to_pad is still < patch size we need to pad more! We pad on both sides
+            # always
+            if need_to_pad[d] + data_shape[d] < self.patch_size[d]:
+                need_to_pad[d] = self.patch_size[d] - data_shape[d]
+
+        # we can now choose the bbox from -need_to_pad // 2 to shape - patch_size + need_to_pad // 2. Here we
+        # define what the upper and lower bound can be to then sample form them with np.random.randint
+        lbs = [- need_to_pad[i] // 2 for i in range(dim)]
+        ubs = [data_shape[i] + need_to_pad[i] // 2 + need_to_pad[i] % 2 - self.patch_size[i] for i in range(dim)]
+
+        # if not force_fg then we can just sample the bbox randomly from lb and ub. Else we need to make sure we get
+        # at least one of the foreground classes in the patch
+        if not force_fg and not self.has_ignore:
+            bbox_lbs = [np.random.randint(lbs[i], ubs[i] + 1) for i in range(dim)]
+            # print('I want a random location')
+        else:
+            if not force_fg and self.has_ignore:
+                selected_class = self.annotated_classes_key
+                if class_locations is None or len(class_locations[selected_class]) == 0:
+                    # no annotated pixels in this case. Not good. But we can hardly skip it here
+                    # print('Warning! No annotated pixels in image!')
+                    selected_class = None
+                # print(f'I have ignore labels and want to pick a labeled area. annotated_classes_key: {self.annotated_classes_key}')
+            elif force_fg:
+                assert class_locations is not None, 'if force_fg is set class_locations cannot be None'
+                if overwrite_class is not None:
+                    assert overwrite_class in class_locations.keys(), 'desired class ("overwrite_class") does not ' \
+                                                                      'have class_locations (missing key)'
+                # this saves us a np.unique. Preprocessing already did that for all cases. Neat.
+                # class_locations keys can also be tuple
+                eligible_classes_or_regions = [i for i in class_locations.keys() if len(class_locations[i]) > 0]
+
+                # if we have annotated_classes_key locations and other classes are present, remove the annotated_classes_key from the list
+                # strange formulation needed to circumvent
+                # ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
+                tmp = [i == self.annotated_classes_key if isinstance(i, tuple) else False for i in eligible_classes_or_regions]
+                if any(tmp):
+                    if len(eligible_classes_or_regions) > 1:
+                        eligible_classes_or_regions.pop(np.where(tmp)[0][0])
+
+                if len(eligible_classes_or_regions) == 0:
+                    # this only happens if some image does not contain foreground voxels at all
+                    selected_class = None
+                    if verbose:
+                        print('case does not contain any foreground classes')
+                else:
+                    # I hate myself. Future me aint gonna be happy to read this
+                    # 2022_11_25: had to read it today. Wasn't too bad
+                    selected_class = eligible_classes_or_regions[np.random.choice(len(eligible_classes_or_regions))] if \
+                        (overwrite_class is None or (overwrite_class not in eligible_classes_or_regions)) else overwrite_class
+                # print(f'I want to have foreground, selected class: {selected_class}')
+            else:
+                raise RuntimeError('lol what!?')
+            voxels_of_that_class = class_locations[selected_class] if selected_class is not None else None
+
+            if voxels_of_that_class is not None and len(voxels_of_that_class) > 0:
+                selected_voxel = voxels_of_that_class[np.random.choice(len(voxels_of_that_class))]
+                # selected voxel is center voxel. Subtract half the patch size to get lower bbox voxel.
+                # Make sure it is within the bounds of lb and ub
+                # i + 1 because we have first dimension 0!
+                bbox_lbs = [max(lbs[i], selected_voxel[i + 1] - self.patch_size[i] // 2) for i in range(dim)]
+            else:
+                # If the image does not contain any foreground classes, we fall back to random cropping
+                bbox_lbs = [np.random.randint(lbs[i], ubs[i] + 1) for i in range(dim)]
+
+        bbox_ubs = [bbox_lbs[i] + self.patch_size[i] for i in range(dim)]
+
+        return bbox_lbs, bbox_ubs
+
+    def generate_train_batch(self):
+        selected_keys = self.get_indices()
+        # preallocate memory for data, seg, and distance maps
+        data_all = np.zeros(self.data_shape, dtype=np.float32)
+        seg_all = np.zeros(self.seg_shape, dtype=np.int16)
+        dist_map_all = np.zeros(self.dist_map_shape, dtype=np.float32)
+        case_properties = []
+
+        for j, i in enumerate(selected_keys):
+            force_fg = self.get_do_oversample(j)
+            data, seg, distance_map, properties = self._data.load_case(i)
+            # Assume using distance transform dataset class
+            # print(f"Data shape: {data.shape}")
+            # print(f"Seg shape: {seg.shape}")
+            # print(f"Distance map shape: {distance_map.shape}")
+            case_properties.append(properties)
+
+            shape = data.shape[1:]
+            dim = len(shape)
+            bbox_lbs, bbox_ubs = self.get_bbox(shape, force_fg, properties['class_locations'])
+
+            valid_bbox_lbs = np.clip(bbox_lbs, a_min=0, a_max=None)
+            valid_bbox_ubs = np.minimum(shape, bbox_ubs)
+
+            # Crop data, seg, and distance map
+            this_slice = tuple([slice(0, data.shape[0])] + [slice(i, j) for i, j in zip(valid_bbox_lbs, valid_bbox_ubs)])
+            data = data[this_slice]
+
+            this_slice = tuple([slice(0, seg.shape[0])] + [slice(i, j) for i, j in zip(valid_bbox_lbs, valid_bbox_ubs)])
+            seg = seg[this_slice]
+
+            # Crop distance map with an additional axis for classes
+            this_slice = tuple([slice(0, distance_map.shape[0])] + [slice(i, j) for i, j in zip(valid_bbox_lbs, valid_bbox_ubs)])
+            distance_map = distance_map[this_slice]
+            # Pad data, seg, and distance map
+            padding = [(-min(0, bbox_lbs[i]), max(bbox_ubs[i] - shape[i], 0)) for i in range(dim)]
+            padding = ((0, 0), *padding)
+            data_all[j] = np.pad(data, padding, 'constant', constant_values=0)
+            seg_all[j] = np.pad(seg, padding, 'constant', constant_values=-1)
+            dist_map_all[j] = np.pad(distance_map, padding, 'constant', constant_values=0)
+
+        if self.transforms is not None:
+            with torch.no_grad():
+                with threadpool_limits(limits=1, user_api=None):
+                    data_all = torch.from_numpy(data_all).float()
+                    seg_all = torch.from_numpy(seg_all).to(torch.int16)
+                    dist_map_all = torch.from_numpy(dist_map_all).to(torch.float16)
+                    images = []
+                    segs = []
+                    dist_maps = []
+                    for b in range(self.batch_size):
+                        tmp = self.transforms(**{'image': data_all[b], 'segmentation': seg_all[b]})
+                        tmp_dist = self.transforms(**{'image': data_all[b], 'segmentation': dist_map_all[b]})
+                        images.append(tmp['image'])
+                        segs.append(tmp['segmentation'])
+                        dist_maps.append(tmp_dist['segmentation'])
+                    data_all = torch.stack(images)
+                    if isinstance(segs[0], list):
+                        seg_all = [torch.stack([s[i] for s in segs]) for i in range(len(segs[0]))]
+                    else:
+                        seg_all = torch.stack(segs)
+                    if isinstance(dist_maps[0], list):
+                        dist_map_all = [torch.stack([d[i] for d in dist_maps]) for i in range(len(dist_maps[0]))]
+                    else:
+                        dist_map_all = torch.stack(dist_maps)
+                    del segs, images, dist_maps
+
+            return {'data': data_all, 'target': seg_all, 'distance_map': dist_map_all, 'keys': selected_keys}
+
+        return {'data': data_all, 'target': seg_all, 'distance_map': dist_map_all, 'keys': selected_keys}

--- a/nnunetv2/training/dataloading/distance_transform_dataset.py
+++ b/nnunetv2/training/dataloading/distance_transform_dataset.py
@@ -1,0 +1,52 @@
+import os
+import torch
+import nibabel as nib
+import numpy as np
+from batchgenerators.utilities.file_and_folder_operations import join, load_pickle, isfile
+from nnunetv2.training.dataloading.utils import get_case_identifiers
+from nnunetv2.training.dataloading.nnunet_dataset import nnUNetDataset
+
+class DistanceTransformDataset(nnUNetDataset):
+    def load_case(self, key):
+        entry = self[key]
+        if 'open_data_file' in entry.keys():
+            data = entry['open_data_file']
+        elif isfile(entry['data_file'][:-4] + ".npy"):
+            data = np.load(entry['data_file'][:-4] + ".npy", 'r')
+            if self.keep_files_open:
+                self.dataset[key]['open_data_file'] = data
+        else:
+            data = np.load(entry['data_file'])['data']
+
+        if 'open_seg_file' in entry.keys():
+            seg = entry['open_seg_file']
+        elif isfile(entry['data_file'][:-4] + "_seg.npy"):
+            seg = np.load(entry['data_file'][:-4] + "_seg.npy", 'r')
+            if self.keep_files_open:
+                self.dataset[key]['open_seg_file'] = seg
+        else:
+            seg = np.load(entry['data_file'])['seg']
+
+        if 'seg_from_prev_stage_file' in entry.keys():
+            if isfile(entry['seg_from_prev_stage_file'][:-4] + ".npy"):
+                seg_prev = np.load(entry['seg_from_prev_stage_file'][:-4] + ".npy", 'r')
+            else:
+                seg_prev = np.load(entry['seg_from_prev_stage_file'])['seg']
+            seg = np.vstack((seg, seg_prev[None]))
+
+        if 'open_dist_file' in entry.keys():
+            dist_map = entry['open_dist_file']
+        elif isfile(entry['data_file'][:-4] + "_dist.npy"):
+            dist_map = np.load(entry['data_file'][:-4] + "_dist.npy", 'r')
+            if self.keep_files_open:
+                self.dataset[key]['open_dist_file'] = dist_map
+        else:
+            dist_map = np.load(entry['data_file'])['dist']
+
+        return data, seg, dist_map, entry['properties']
+
+    @staticmethod
+    def load_nifti(file_path):
+        # Implement method to load .nii.gz files
+        nii = nib.load(file_path)
+        return torch.tensor(nii.get_fdata(), dtype=torch.float32)

--- a/nnunetv2/training/loss/compound_losses.py
+++ b/nnunetv2/training/loss/compound_losses.py
@@ -1,6 +1,7 @@
 import torch
 from nnunetv2.training.loss.dice import SoftDiceLoss, MemoryEfficientSoftDiceLoss
 from nnunetv2.training.loss.robust_ce_loss import RobustCrossEntropyLoss, TopKLoss
+from nnunetv2.training.loss.focal_loss import FocalLoss
 from nnunetv2.utilities.helpers import softmax_helper_dim1
 from torch import nn
 
@@ -153,4 +154,57 @@ class DC_and_topk_loss(nn.Module):
             if self.weight_ce != 0 and (self.ignore_label is None or num_fg > 0) else 0
 
         result = self.weight_ce * ce_loss + self.weight_dice * dc_loss
+        return result
+
+class DC_and_Focal_loss(nn.Module):
+    def __init__(self, soft_dice_kwargs, focal_kwargs, weight_focal=1, weight_dice=1, ignore_label=None,
+                 dice_class=SoftDiceLoss):
+        """
+        Weights for Focal and Dice do not need to sum to one. You can set whatever you want.
+        :param soft_dice_kwargs:
+        :param ce_kwargs:
+        :param aggregate:
+        :param square_dice:
+        :param weight_focal:
+        :param weight_dice:
+        """
+        super(DC_and_Focal_loss, self).__init__()
+        # if ignore_label is not None:
+        #     focal_kwargs['ignore_index'] = ignore_label
+
+        self.weight_dice = weight_dice
+        self.weight_focal = weight_focal
+        self.ignore_label = ignore_label
+
+        self.focal = FocalLoss(**focal_kwargs)
+        self.dc = dice_class(apply_nonlin=softmax_helper_dim1, **soft_dice_kwargs)
+
+    def forward(self, net_output: torch.Tensor, target: torch.Tensor):
+        """
+        target must be b, c, x, y(, z) with c=1
+        :param net_output:
+        :param target:
+        :return:
+        """
+        if self.ignore_label is not None:
+            assert target.shape[1] == 1, 'ignore label is not implemented for one hot encoded target variables ' \
+                                         '(DC_and_Focal_loss)'
+            mask = target != self.ignore_label
+            # remove ignore label from target, replace with one of the known labels. It doesn't matter because we
+            # ignore gradients in those areas anyway
+            target_dice = torch.where(mask, target, 0)
+            num_fg = mask.sum()
+        else:
+            target_dice = target
+            mask = None
+
+        dc_loss = self.dc(net_output, target_dice, loss_mask=mask) \
+            if self.weight_dice != 0 else 0
+        focal_loss = self.focal(net_output, target[:, 0]) \
+            if self.weight_focal != 0 and (self.ignore_label is None or num_fg > 0) else 0
+
+        # print(f"Dice loss: {dc_loss}")
+        # print(f"Focal loss: {focal_loss}")
+
+        result = self.weight_focal * focal_loss + self.weight_dice * dc_loss
         return result

--- a/nnunetv2/training/loss/dist_losses.py
+++ b/nnunetv2/training/loss/dist_losses.py
@@ -1,0 +1,70 @@
+from typing import Callable
+
+import torch
+import numpy as np
+from nnunetv2.utilities.ddp_allgather import AllGatherGrad
+from nnunetv2.training.loss.dice import MemoryEfficientSoftDiceLoss
+from torch import nn
+
+
+class MemoryEfficientDistDiceLoss(MemoryEfficientSoftDiceLoss):
+    def __init__(self, apply_nonlin: Callable = None, batch_dice: bool = False, do_bg: bool = True, smooth: float = 1.0,
+                 ddp: bool = True):
+        super(MemoryEfficientDistDiceLoss, self).__init__(apply_nonlin=apply_nonlin, batch_dice=batch_dice, do_bg=do_bg, smooth=smooth, ddp=ddp)
+
+        self.do_bg = do_bg
+        self.batch_dice = batch_dice
+        self.apply_nonlin = apply_nonlin
+        self.smooth = smooth
+        self.ddp = ddp
+
+    def forward(self, x, y, dist_map, loss_mask=None):
+        dist_weight = torch.exp(-dist_map)  # Solves vanishing gradient
+
+        if self.apply_nonlin is not None:
+            x = self.apply_nonlin(x)
+
+        # make everything shape (b, c)
+        axes = tuple(range(2, x.ndim))
+
+        with torch.no_grad():
+            if x.ndim != y.ndim:
+                y = y.view((y.shape[0], 1, *y.shape[1:]))
+
+            if x.shape == y.shape:
+                # if this is the case then gt is probably already a one hot encoding
+                y_onehot = y
+            else:
+                y_onehot = torch.zeros(x.shape, device=x.device, dtype=torch.bool)
+                y_onehot.scatter_(1, y.long(), 1)
+
+            if not self.do_bg:
+                y_onehot = y_onehot[:, 1:]
+
+            sum_gt = (y_onehot * dist_weight).sum(axes) if loss_mask is None else (y_onehot * loss_mask * dist_weight).sum(axes)
+
+        # this one MUST be outside the with torch.no_grad(): context. Otherwise no gradients for you
+        if not self.do_bg:
+            x = x[:, 1:]
+
+        if loss_mask is None:
+            intersect = (x * y_onehot * dist_weight).sum(axes)
+            sum_pred = (x * dist_weight).sum(axes)
+        else:
+            intersect = (x * loss_mask * y_onehot).sum(axes)
+            sum_pred = (x * loss_mask * dist_weight).sum(axes)
+
+        if self.batch_dice:
+            if self.ddp:
+                intersect = AllGatherGrad.apply(intersect).sum(0)
+                sum_pred = AllGatherGrad.apply(sum_pred).sum(0)
+                sum_gt = AllGatherGrad.apply(sum_gt).sum(0)
+
+            intersect = intersect.sum(0)
+            sum_pred = sum_pred.sum(0)
+            sum_gt = sum_gt.sum(0)
+
+        dc = (2 * intersect + self.smooth) / (torch.clip(sum_gt + sum_pred + self.smooth, min=1e-8))
+
+        dc = dc.mean()
+        return -dc

--- a/nnunetv2/training/loss/focal_loss.py
+++ b/nnunetv2/training/loss/focal_loss.py
@@ -1,0 +1,99 @@
+#    Copyright 2020 Division of Medical Image Computing, German Cancer Research Center (DKFZ), Heidelberg, Germany
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+import torch
+from torch import nn, Tensor
+import numpy as np
+import torch.nn.functional as F
+
+class FocalLoss(nn.Module):
+    def __init__(self, gamma=2, alpha=1, reduction='mean'):
+        """
+        Args:
+            gamma (float): Focusing parameter (default: 2).
+            alpha (float or list or None): Weighting factor for class imbalance (default: None).
+                If None, alpha will be computed based on the class frequencies.
+            reduction (str): Specifies the reduction to apply to the output ('none', 'mean', 'sum'). Default: 'mean'.
+        """
+        super(FocalLoss, self).__init__()
+        self.gamma = gamma
+        self.alpha = alpha
+        self.reduction = reduction
+
+    def forward(self, inputs, targets):
+        """
+        Compute the focal loss.
+
+        Args:
+            inputs (torch.Tensor): The predicted logits, shape (N, C, D, H, W) or (N, C, H, W).
+            targets (torch.Tensor): The ground truth, shape (N, D, H, W) or (N, H, W), where N is batch size.
+            
+        Returns:
+            torch.Tensor: The computed focal loss value.
+        """
+        # Ensure targets are in long type for indexing
+        targets = targets.long()
+        if targets.ndim == inputs.ndim:
+            assert targets.shape[1] == 1
+            targets = targets[:, 0]
+
+        # If alpha is not provided, calculate it based on class frequencies
+        if self.alpha is None:
+            # Flatten the targets to compute class distribution
+            target_flat = targets.view(-1)
+
+            # Use torch.bincount() to get the number of occurrences for each class
+            class_counts = torch.bincount(target_flat, minlength=inputs.shape[1]).float()
+
+            total_count = target_flat.size(0)
+
+            # Compute alpha: Inverse of class frequencies, normalized to sum to 1
+            alpha = 1.0 / (class_counts + 1e-7)  # Add small epsilon to avoid division by zero
+            alpha /= alpha.sum()  # Normalize the alpha values
+            
+            # Transfer to the same device as inputs
+            alpha = alpha.to(inputs.device)
+        else:
+            # If alpha is provided as a constant or tensor, ensure it is on the correct device
+            if isinstance(self.alpha, (list, torch.Tensor)):
+                alpha = torch.tensor(self.alpha, dtype=torch.float32, device=inputs.device)
+            else:
+                alpha = torch.full((inputs.shape[1],), self.alpha, dtype=torch.float32, device=inputs.device)
+
+        # Softmax over the channel dimension (class dimension)
+        probs = F.softmax(inputs, dim=1)
+
+        # Expand targets to match the shape of probs (batch_size, D, H, W) -> (batch_size, 1, D, H, W)
+        targets_expanded = targets.unsqueeze(1)  # Shape: [N, 1, D, H, W]
+
+        # Index the predicted probabilities for the correct class using torch.gather
+        # torch.gather takes the dimension to gather along (1 - for classes), and the index tensor (targets_expanded)
+        pt = probs.gather(1, targets_expanded)  # Shape: [N, 1, D, H, W]
+        pt = pt.squeeze(1)  # Remove the class dimension: Shape: [N, D, H, W]
+
+        # Clamp probabilities to avoid log(0)
+        pt = torch.clamp(pt, min=1e-8, max=1.0 - 1e-8)
+
+        # Focal loss computation
+        loss = -alpha[targets] * (1 - pt) ** self.gamma * torch.log(pt)
+
+        # Apply reduction
+        if self.reduction == 'mean':
+            return loss.mean()
+        elif self.reduction == 'sum':
+            return loss.sum()
+        elif self.reduction == 'none':
+            return loss
+        else:
+            raise ValueError(f"Invalid reduction type: {self.reduction}")

--- a/nnunetv2/training/loss/hausdorff.py
+++ b/nnunetv2/training/loss/hausdorff.py
@@ -1,0 +1,334 @@
+import torch
+from torch import nn
+from torch.nn import functional as F
+from nnunet.training.loss_functions.dice_loss import SoftDiceLoss, SoftDiceLossSquared, DC_and_CE_loss
+from nnunet.training.loss_functions.crossentropy import RobustCrossEntropyLoss
+from nnunet.utilities.nd_softmax import softmax_helper
+from nnunet.utilities.tensor_utilities import sum_tensor
+import numpy as np
+import time as time
+
+import math
+from sklearn.utils.extmath import cartesian
+from sklearn.metrics.pairwise import pairwise_distances
+
+import cv2 as cv
+from scipy.ndimage.morphology import distance_transform_edt as edt
+from scipy.ndimage import convolve
+
+torch.set_default_dtype(torch.float32)
+
+"""
+Hausdorff loss implementation based on paper:
+https://arxiv.org/pdf/1904.10030.pdf
+Copied from: https://github.com/PatRyg99/HausdorffLoss/blob/master/hausdorff_loss.py
+"""
+
+class HausdorffDTLoss(nn.Module):
+    """Binary Hausdorff loss based on distance transform"""
+
+    def __init__(self, alpha=2.0, **kwargs):
+        super(HausdorffDTLoss, self).__init__()
+        self.alpha = alpha
+
+    @torch.no_grad()
+    def distance_field(self, img: np.ndarray) -> np.ndarray:
+        field = np.zeros_like(img)
+
+        for batch in range(len(img)):
+            fg_mask = img[batch] > 0.5
+
+            if fg_mask.any():
+                bg_mask = ~fg_mask
+
+                fg_dist = edt(fg_mask)
+                bg_dist = edt(bg_mask)
+
+                field[batch] = fg_dist + bg_dist
+
+        return field
+
+    def forward(
+        self, pred: torch.Tensor, target: torch.Tensor, debug=False
+    ) -> torch.Tensor:
+        """
+        Uses one binary channel: 1 - fg, 0 - bg
+        pred: (b, 1, x, y, z) or (b, 1, x, y)
+        target: (b, 1, x, y, z) or (b, 1, x, y)
+        """
+        assert pred.dim() == 4 or pred.dim() == 5, "Only 2D and 3D supported"
+        assert (
+            pred.dim() == target.dim()
+        ), "Prediction and target need to be of same dimension"
+
+        # pred = torch.sigmoid(pred)
+
+        pred_dt = torch.from_numpy(self.distance_field(pred.cpu().numpy())).float()
+        target_dt = torch.from_numpy(self.distance_field(target.cpu().numpy())).float()
+
+        pred_error = (pred - target) ** 2
+        distance = pred_dt ** self.alpha + target_dt ** self.alpha
+
+        dt_field = pred_error * distance
+        loss = dt_field.mean()
+
+        if debug:
+            return (
+                loss.cpu().numpy(),
+                (
+                    dt_field.cpu().numpy()[0, 0],
+                    pred_error.cpu().numpy()[0, 0],
+                    distance.cpu().numpy()[0, 0],
+                    pred_dt.cpu().numpy()[0, 0],
+                    target_dt.cpu().numpy()[0, 0],
+                ),
+            )
+
+        else:
+            return loss
+
+
+class BinaryHausdorffERLoss(nn.Module):
+    """Binary Hausdorff loss based on morphological erosion"""
+
+    def __init__(self, alpha=2.0, erosions=10, **kwargs):
+        super(BinaryHausdorffERLoss, self).__init__()
+        self.alpha = alpha
+        self.erosions = erosions
+        self.prepare_kernels()
+
+    def prepare_kernels(self):
+        cross = np.array([cv.getStructuringElement(cv.MORPH_CROSS, (3, 3))])
+        bound = np.array([[[0, 0, 0], [0, 1, 0], [0, 0, 0]]])
+
+        self.kernel2D = cross * 0.2
+        self.kernel3D = np.array([bound, cross, bound]) * (1 / 7)
+
+    @torch.no_grad()
+    def perform_erosion(
+        self, pred: np.ndarray, target: np.ndarray, debug
+    ) -> np.ndarray:
+        bound = (pred - target) ** 2
+
+        if bound.ndim == 5:
+            kernel = self.kernel3D
+        elif bound.ndim == 4:
+            kernel = self.kernel2D
+        else:
+            raise ValueError(f"Dimension {bound.ndim} is nor supported.")
+
+        eroted = np.zeros_like(bound)
+        erosions = []
+
+        for batch in range(len(bound)):
+
+            # debug
+            erosions.append(np.copy(bound[batch][0]))
+
+            for k in range(self.erosions):
+
+                # compute convolution with kernel
+                dilation = convolve(bound[batch], kernel, mode="constant", cval=0.0)
+
+                # apply soft thresholding at 0.5 and normalize
+                erosion = dilation - 0.5
+                erosion[erosion < 0] = 0
+
+                if erosion.ptp() != 0:
+                    erosion = (erosion - erosion.min()) / erosion.ptp()
+
+                # save erosion and add to loss
+                bound[batch] = erosion
+                eroted[batch] += erosion * (k + 1) ** self.alpha
+
+                if debug:
+                    erosions.append(np.copy(erosion[0]))
+
+        # image visualization in debug mode
+        if debug:
+            return eroted, erosions
+        else:
+            return eroted
+
+    def forward(
+        self, pred: torch.Tensor, target: torch.Tensor, debug=False
+    ) -> torch.Tensor:
+        """
+        Uses one binary channel: 1 - fg, 0 - bg
+        pred: (b, 1, x, y, z) or (b, 1, x, y)
+        target: (b, 1, x, y, z) or (b, 1, x, y)
+        """
+        assert pred.dim() == 4 or pred.dim() == 5, "Only 2D and 3D supported"
+        assert (
+            pred.dim() == target.dim()
+        ), "Prediction and target need to be of same dimension"
+
+        # Was commented out before
+        pred = softmax_helper(pred)
+
+        if debug:
+            eroted, erosions = self.perform_erosion(
+                pred.cpu().numpy(), target.cpu().numpy(), debug
+            )
+            return eroted.mean(), erosions
+
+        else:
+            eroted = torch.from_numpy(
+                self.perform_erosion(pred.detach().cpu().numpy(), target.detach().cpu().numpy(), debug)
+            ).float()
+
+            loss = eroted.mean()
+
+            return loss
+
+class HausdorffERLoss(BinaryHausdorffERLoss):
+    """Multiclass Hausdorff loss based on morphological erosion"""
+
+    def __init__(self, alpha=2.0, erosions=10, **kwargs):
+        super(HausdorffERLoss, self).__init__(alpha, erosions)
+
+    def prepare_kernels(self):
+        cross = np.array([cv.getStructuringElement(cv.MORPH_CROSS, (3, 3))])
+        bound = np.array([[[0, 0, 0], [0, 1, 0], [0, 0, 0]]])
+
+        self.kernel2D = torch.from_numpy(cross * 0.2)
+        self.kernel3D = torch.from_numpy(np.array([bound, cross, bound]) * (1 / 7))
+
+    # @torch.no_grad()
+    def perform_erosion(self, pred: torch.Tensor, target: torch.Tensor, debug) -> torch.Tensor:
+        bound = (pred - target) ** 2
+
+        if bound.ndim == 5:
+            convolve = F.conv3d
+            kernel = self.kernel3D
+        elif bound.ndim == 4:
+            convolve = F.conv2d
+            kernel = self.kernel2D
+        else:
+            raise ValueError(f"Dimension {bound.ndim} is nor supported.")
+
+        eroted = torch.zeros_like(bound)
+        erosions = []
+
+        for batch in range(len(bound)):
+
+            if debug: erosions.append(np.copy(bound[batch][0]))
+
+            for k in range(self.erosions):
+                breakpoint()
+                # compute convolution with kernel
+                dilation = convolve(bound[batch], kernel, stride=1)
+
+                # apply soft thresholding at 0.5 and normalize
+                erosion = dilation - 0.5
+                erosion[erosion < 0] = 0
+
+                if torch.max(erosion) > torch.min(erosion):
+                    erosion = (erosion - torch.min(erosion)) / (torch.max(erosion)-torch.min(erosion))
+
+                # save erosion and add to loss
+                bound[batch] = erosion
+                eroted[batch] += erosion * (k + 1) ** self.alpha
+
+                if debug: erosions.append(np.copy(erosion[0]))
+
+        # image visualization in debug mode
+        if debug:
+            return eroted, erosions
+        else:
+            return eroted
+
+    def forward(
+        self, pred: torch.Tensor, target: torch.Tensor, debug=False
+    ) -> torch.Tensor:
+        """
+        Uses one binary channel: 1 - fg, 0 - bg
+        pred: (b, c, x, y, z) or (b, c, x, y)
+        target: (b, 1, x, y, z) or (b, 1, x, y)
+        """
+        assert pred.dim() == 4 or pred.dim() == 5, "Only 2D and 3D supported"
+        assert (
+            pred.dim() == target.dim()
+        ), "Prediction and target need to be of same dimension"
+
+        start = time.time()
+        # Was commented out before
+        pred = softmax_helper(pred)
+        
+        shp_x = pred.shape
+        shp_y = target.shape
+        with torch.no_grad():
+            if len(shp_x) != len(shp_y):
+                target = target.view((shp_y[0], 1, *shp_y[1:]))
+
+            if all([i == j for i, j in zip(pred.shape, target.shape)]):
+                # if this is the case then gt is probably already a one hot encoding
+                y_onehot = target
+            else:
+                target = target.long()
+                y_onehot = torch.zeros(shp_x)
+                if pred.device.type == "cuda":
+                    y_onehot = y_onehot.cuda(pred.device.index)
+                y_onehot.scatter_(1, target, 1).float()
+
+        loss = 0
+        for c in range(shp_x[1]):
+            eroted = self.perform_erosion(pred[:,c,...], y_onehot[:,c,...], debug)
+
+            loss += eroted.mean()
+
+        end = time.time()
+        print(f"Hausdorff ER time: {end-start} seconds")
+
+        return loss/shp_x[1]
+
+class DC_CE_and_HausdorffER_loss(DC_and_CE_loss):
+    def __init__(self, soft_dice_kwargs, ce_kwargs, aggregate="sum", square_dice=False, weight_ce=1, weight_dice=1, weight_ahd=1,
+                 log_dice=False, ignore_label=None):
+        """
+        CAREFUL. Weights for CE and Dice do not need to sum to one. You can set whatever you want.
+        :param soft_dice_kwargs:
+        :param ce_kwargs:
+        :param aggregate:
+        :param square_dice:
+        :param weight_ce:
+        :param weight_dice:
+        :param weight_whd:
+        """
+        super().__init__(soft_dice_kwargs, ce_kwargs, aggregate, square_dice, weight_ce, weight_dice,
+                         log_dice, ignore_label)
+
+        self.hd = HausdorffERLoss()
+        self.weight_hd = weight_ahd
+
+    def forward(self, net_output, target):
+        """
+        target must be b, c, x, y(, z) with c=1
+        :param net_output:
+        :param target:
+        :return:
+        """
+        if self.ignore_label is not None:
+            assert target.shape[1] == 1, 'not implemented for one hot encoding'
+            mask = target != self.ignore_label
+            target[~mask] = 0
+            mask = mask.float()
+        else:
+            mask = None
+
+        dc_loss = self.dc(net_output, target, loss_mask=mask) if self.weight_dice != 0 else 0
+        if self.log_dice:
+            dc_loss = -torch.log(-dc_loss)
+
+        ce_loss = self.ce(net_output, target[:, 0].long()) if self.weight_ce != 0 else 0
+        if self.ignore_label is not None:
+            ce_loss *= mask[:, 0]
+            ce_loss = ce_loss.sum() / mask.sum()
+
+        hd_loss = self.hd(net_output, target)
+
+        if self.aggregate == "sum":
+            result = self.weight_ce * ce_loss + self.weight_dice * dc_loss + self.weight_hd * hd_loss
+        else:
+            raise NotImplementedError("nah son") # reserved for other stuff (later)
+        return result

--- a/nnunetv2/training/loss/nnunetv1_dist_dice_loss.py
+++ b/nnunetv2/training/loss/nnunetv1_dist_dice_loss.py
@@ -1,0 +1,264 @@
+import torch
+from nnunet.training.loss_functions.dice_loss import SoftDiceLoss, SoftDiceLossSquared, DC_and_CE_loss
+from nnunet.utilities.nd_softmax import softmax_helper
+from nnunet.utilities.tensor_utilities import sum_tensor
+from torch import nn
+import numpy as np
+import time as time
+import edt
+
+ANISOTROPY = (0.096, 0.096, 0.096)
+
+def get_dist_tp_fp_fn_tn(net_output, gt, mask=None, square=False):
+    """
+    net_output must be (b, c, x, y(, z)))
+    gt must be a label map (shape (b, 1, x, y(, z)) OR shape (b, x, y(, z))) or one hot encoding (b, c, x, y(, z))
+    if mask is provided it must have shape (b, 1, x, y(, z)))
+    :param net_output:
+    :param gt:
+    :param axes: can be (, ) = no summation
+    :param mask: mask must be 1 for valid pixels and 0 for invalid pixels
+    :param square: if True then fp, tp and fn will be squared
+    :return: Confusion matrix Tensors scaled by voxel-wise distance maps for each class
+
+    NOTE: This is different from get_tp_fp_fn_tn, which returns the summed values.
+
+    Heavily influenced by: https://github.com/seung-lab/euclidean-distance-transform-3d
+    """
+    shp_x = net_output.shape
+    shp_y = gt.shape
+    num_batches = shp_x[0]
+    num_classes = shp_x[1]
+
+    with torch.no_grad():
+        if len(shp_x) != len(shp_y):
+            # gt is likely (b, x, y(, z))
+            gt = gt.view((num_batches, 1, *shp_x[2:]))
+
+        if all([i == j for i, j in zip(net_output.shape, gt.shape)]):
+            # if this is the case then gt is probably already a one hot encoding
+            y_onehot = gt
+        else:
+            # gt is likely (b, 1, x, y(, z))
+            gt = gt.long()
+            y_onehot = torch.zeros(shp_x, device=net_output.device)
+            y_onehot.scatter_(1, gt, 1)
+
+        # gt_resized is of shape (b*x, y(, z)) since batches not supported in edt
+        # gt_resized = gt.squeeze()
+        # if num_batches > 1: gt_resized = torch.cat((*gt_resized[:,...],))
+        # assert gt_resized.shape[0] == num_batches * shp_x[2], 'Batches were not concatenated properly!'
+        
+        dt = np.zeros(shp_y) # (b, 1, x, y(, z))
+        gt_resized = gt.squeeze().cpu().numpy() + 1 # +1 to turn background into foreground segmentation for distance mapping
+        if num_batches > 1:
+            for b in range(num_batches):
+                dt[b,0,...] = edt.edt(gt_resized[b,...], anisotropy=ANISOTROPY, parallel=0) + 1
+        else: dt[0,0,...] = edt.edt(gt_resized, anisotropy=ANISOTROPY, parallel=0) + 1
+
+    dt = torch.nan_to_num(torch.from_numpy(dt), nan=1.0, posinf=1.0, neginf=1.0)
+    if net_output.device.type == "cuda":
+        dt = dt.cuda(net_output.device.index)
+
+    # dt is resized from (b*x, y(, z)) to (b, 1, x, y(, z))
+    # dt = torch.stack(torch.split(dt, num_batches*[shp_x[2]], dim=0), dim=0).unsqueeze(dim=1)
+
+    tp = net_output * y_onehot
+    fp = net_output * (1 - y_onehot)
+    fn = (1 - net_output) * y_onehot
+    tn = (1 - net_output) * (1 - y_onehot)
+
+    if mask is not None:
+        tp = torch.stack(tuple(x_i * mask[:, 0] for x_i in torch.unbind(tp, dim=1)), dim=1)
+        fp = torch.stack(tuple(x_i * mask[:, 0] for x_i in torch.unbind(fp, dim=1)), dim=1)
+        fn = torch.stack(tuple(x_i * mask[:, 0] for x_i in torch.unbind(fn, dim=1)), dim=1)
+        tn = torch.stack(tuple(x_i * mask[:, 0] for x_i in torch.unbind(tn, dim=1)), dim=1)
+
+    if square:
+        tp = tp ** 2
+        fp = fp ** 2
+        fn = fn ** 2
+        tn = tn ** 2
+
+    fp = fp * dt
+    fn = fn * dt
+
+    return tp, fp, fn, tn
+
+class DistancePenalization(nn.Module):
+    def __init__(self, apply_nonlin=None, do_bg=False, smooth=1e-5):
+        """
+        """
+        super(DistancePenalization, self).__init__()
+
+        self.do_bg = do_bg
+        self.apply_nonlin = apply_nonlin
+        self.smooth = smooth
+
+    def forward(self, x, y, loss_mask=None):
+        if self.apply_nonlin is not None:
+            x = self.apply_nonlin(x)
+
+        _, fp, fn, _ = get_dist_tp_fp_fn_tn(x, y, loss_mask, False)
+        
+        if not self.do_bg:
+            if self.batch_dice:
+                fp = fp[1:]
+                fn = fn[1:]
+            else:
+                fp = fp[:, 1:]
+                fn = fn[:, 1:]
+                
+        fp = torch.mean(fp)
+        fn = torch.mean(fn)
+
+        return fp + fn + self.smooth
+
+class DistDiceLoss(SoftDiceLoss):
+    def __init__(self, apply_nonlin=None, batch_dice=False, do_bg=False, smooth=1e-5):
+        """
+        Distance map penalized Dice loss for multiclass segmentation
+        Motivated by: https://openreview.net/forum?id=B1eIcvS45V
+        Distance Map Loss Penalty Term for Semantic Segmentation
+        Adapted from the Binary version: https://github.com/JunMa11/SegLoss/blob/master/losses_pytorch/boundary_loss.py
+        """
+        super(DistDiceLoss, self).__init__(apply_nonlin, batch_dice, do_bg, smooth)
+
+    def forward(self, x, y, loss_mask=None):
+        shp_x = x.shape
+
+        if self.batch_dice:
+            axes = [0] + list(range(2, len(shp_x)))
+        else:
+            axes = list(range(2, len(shp_x)))
+
+        if self.apply_nonlin is not None:
+            x = self.apply_nonlin(x)
+
+        tp, fp, fn, _ = get_dist_tp_fp_fn_tn(x, y, loss_mask, False)
+
+        if len(axes) > 0:
+            tp = sum_tensor(tp, axes, keepdim=False)
+            fp = sum_tensor(fp, axes, keepdim=False)
+            fn = sum_tensor(fn, axes, keepdim=False)
+
+        nominator = 2 * tp + self.smooth
+        denominator = 2 * tp + fp + fn + self.smooth
+
+        dc = nominator / (denominator + 1e-8)
+
+        if not self.do_bg:
+            if self.batch_dice:
+                dc = dc[1:]
+            else:
+                dc = dc[:, 1:]
+        dc = dc.mean()
+
+        return -dc
+
+class DistDC_and_CE_loss(DC_and_CE_loss):
+    def __init__(self, soft_dice_kwargs, ce_kwargs, aggregate="sum", square_dice=False, weight_ce=1, weight_dice=1,
+                 log_dice=False, ignore_label=None):
+        """
+        CAREFUL. Weights for CE and Distance-Mapped Dice do not need to sum to one. You can set whatever you want.
+        :param soft_dice_kwargs:
+        :param ce_kwargs:
+        :param aggregate:
+        :param square_dice:
+        :param weight_ce:
+        :param weight_dice:
+        """
+        super().__init__(soft_dice_kwargs, ce_kwargs, aggregate, square_dice, weight_ce, weight_dice,
+                         log_dice, ignore_label)
+
+        self.dc = DistDiceLoss(apply_nonlin=softmax_helper, **soft_dice_kwargs)
+
+    def forward(self, net_output, target):
+        """
+        target must be b, c, x, y(, z) with c=1
+        :param net_output:
+        :param target:
+        :return:
+        """
+        start = time.time()
+        if self.ignore_label is not None:
+            assert target.shape[1] == 1, 'not implemented for one hot encoding'
+            mask = target != self.ignore_label
+            target[~mask] = 0
+            mask = mask.float()
+        else:
+            mask = None
+
+        dc_loss = self.dc(net_output, target) if self.weight_dice != 0 else 0
+        if self.log_dice:
+            dc_loss = -torch.log(-dc_loss)
+
+        print(f"Dist Dice: {-dc_loss}")
+        ce_loss = self.ce(net_output, target[:, 0].long()) if self.weight_ce != 0 else 0
+        if self.ignore_label is not None:
+            ce_loss *= mask[:, 0]
+            ce_loss = ce_loss.sum() / mask.sum()
+
+        if self.aggregate == "sum":
+            result = self.weight_ce * ce_loss + self.weight_dice * dc_loss
+        else:
+            raise NotImplementedError("nah son") # reserved for other stuff (later)
+
+        end = time.time()
+        print(f"Dist Dice Time: {end-start} seconds")
+        return result
+
+class DC_CE_DP_loss(DC_and_CE_loss):
+    def __init__(self, soft_dice_kwargs, ce_kwargs, aggregate="sum", square_dice=False, weight_ce=1, weight_dice=1,
+                 weight_dp=1, log_dice=False, ignore_label=None):
+        """
+        CAREFUL. Weights for CE, Dice and distance penalization do not need to sum to one. You can set whatever you want.
+        :param soft_dice_kwargs:
+        :param ce_kwargs:
+        :param aggregate:
+        :param square_dice:
+        :param weight_ce:
+        :param weight_dice:
+        :param weight_dp:
+        """
+        super().__init__(soft_dice_kwargs, ce_kwargs, aggregate, square_dice, weight_ce, weight_dice,
+                         log_dice, ignore_label)
+
+        self.dp = DistancePenalization(apply_nonlin=softmax_helper)
+        self.weight_dp = weight_dp
+
+    def forward(self, net_output, target):
+        """
+        target must be b, c, x, y(, z) with c=1
+        :param net_output:
+        :param target:
+        :return:
+        """
+        start = time.time()
+        if self.ignore_label is not None:
+            assert target.shape[1] == 1, 'not implemented for one hot encoding'
+            mask = target != self.ignore_label
+            target[~mask] = 0
+            mask = mask.float()
+        else:
+            mask = None
+
+        dc_loss = self.dc(net_output, target) if self.weight_dice != 0 else 0
+        if self.log_dice:
+            dc_loss = -torch.log(-dc_loss)
+
+        dp_loss = self.dp(net_output, target) if self.weight_dp != 0 else 0
+
+        ce_loss = self.ce(net_output, target[:, 0].long()) if self.weight_ce != 0 else 0
+        if self.ignore_label is not None:
+            ce_loss *= mask[:, 0]
+            ce_loss = ce_loss.sum() / mask.sum()
+
+        if self.aggregate == "sum":
+            result = self.weight_ce * ce_loss + self.weight_dice * dc_loss + self.weight_dp * dp_loss
+        else:
+            raise NotImplementedError("nah son") # reserved for other stuff (later)
+
+        end = time.time()
+        print(f"Loss Calculation Time: {end-start}")
+        return result

--- a/nnunetv2/training/nnUNetTrainer/nnUNetTrainer.py
+++ b/nnunetv2/training/nnUNetTrainer/nnUNetTrainer.py
@@ -149,7 +149,7 @@ class nnUNetTrainer(object):
         self.oversample_foreground_percent = 0.33
         self.num_iterations_per_epoch = 250
         self.num_val_iterations_per_epoch = 50
-        self.num_epochs = 1000
+        self.num_epochs = 500
         self.current_epoch = 0
         self.enable_deep_supervision = True
 

--- a/nnunetv2/training/nnUNetTrainer/variants/loss/from_nnunetv1/nnUNetTrainerV2_Loss_DiceCE_DP.py
+++ b/nnunetv2/training/nnUNetTrainer/variants/loss/from_nnunetv1/nnUNetTrainerV2_Loss_DiceCE_DP.py
@@ -1,0 +1,25 @@
+#    Copyright 2020 Division of Medical Image Computing, German Cancer Research Center (DKFZ), Heidelberg, Germany
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+
+from nnunet.training.network_training.nnUNetTrainerV2 import nnUNetTrainerV2
+from nnunet.training.loss_functions.dist_dice_loss import DC_CE_DP_loss
+
+
+class nnUNetTrainerV2_Loss_DiceCE_DP(nnUNetTrainerV2):
+    def __init__(self, plans_file, fold, output_folder=None, dataset_directory=None, batch_dice=True, stage=None,
+                 unpack_data=True, deterministic=True, fp16=False):
+        super().__init__(plans_file, fold, output_folder, dataset_directory, batch_dice, stage, unpack_data,
+                         deterministic, fp16)
+        self.loss = DC_CE_DP_loss({'batch_dice': self.batch_dice, 'smooth': 1e-5, 'do_bg': False}, {})

--- a/nnunetv2/training/nnUNetTrainer/variants/loss/from_nnunetv1/nnUNetTrainerV2_Loss_DiceCE_HausdorffER.py
+++ b/nnunetv2/training/nnUNetTrainer/variants/loss/from_nnunetv1/nnUNetTrainerV2_Loss_DiceCE_HausdorffER.py
@@ -1,0 +1,25 @@
+#    Copyright 2020 Division of Medical Image Computing, German Cancer Research Center (DKFZ), Heidelberg, Germany
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+
+from nnunet.training.network_training.nnUNetTrainerV2 import nnUNetTrainerV2
+from nnunet.training.loss_functions.hausdorff import DC_CE_and_HausdorffER_loss
+
+
+class nnUNetTrainerV2_Loss_DiceCE_HausdorffER(nnUNetTrainerV2):
+    def __init__(self, plans_file, fold, output_folder=None, dataset_directory=None, batch_dice=True, stage=None,
+                 unpack_data=True, deterministic=True, fp16=False):
+        super().__init__(plans_file, fold, output_folder, dataset_directory, batch_dice, stage, unpack_data,
+                         deterministic, fp16)
+        self.loss = DC_CE_and_HausdorffER_loss({'batch_dice': self.batch_dice, 'smooth': 1e-5, 'do_bg': False}, {})

--- a/nnunetv2/training/nnUNetTrainer/variants/loss/from_nnunetv1/nnUNetTrainerV2_Loss_DiceFocalCE.py
+++ b/nnunetv2/training/nnUNetTrainer/variants/loss/from_nnunetv1/nnUNetTrainerV2_Loss_DiceFocalCE.py
@@ -1,0 +1,28 @@
+#    Copyright 2020 Division of Medical Image Computing, German Cancer Research Center (DKFZ), Heidelberg, Germany
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+from nnunet.training.loss_functions.dice_loss import DC_and_FocalCE_loss
+from nnunet.training.network_training.nnUNetTrainerV2 import nnUNetTrainerV2
+from torch import nn
+
+
+class nnUNetTrainerV2_Loss_DiceFocalCE(nnUNetTrainerV2):
+    def __init__(self, plans_file, fold, output_folder=None, dataset_directory=None, batch_dice=True, stage=None,
+                 unpack_data=True, deterministic=True, fp16=False):
+        super().__init__(plans_file, fold, output_folder, dataset_directory, batch_dice, stage,
+                                              unpack_data, deterministic, fp16)
+        print("Focal loss parameters: {'alpha':0.25, 'gamma':2, 'smooth':1e-5}")
+        self.loss = DC_and_FocalCE_loss({'batch_dice': self.batch_dice, 'smooth': 1e-5, 'do_bg': False}, {'alpha':0.25, 'gamma':2, 'smooth':1e-5})
+
+

--- a/nnunetv2/training/nnUNetTrainer/variants/loss/from_nnunetv1/nnUNetTrainerV2_Loss_DistDiceCE.py
+++ b/nnunetv2/training/nnUNetTrainer/variants/loss/from_nnunetv1/nnUNetTrainerV2_Loss_DistDiceCE.py
@@ -1,0 +1,25 @@
+#    Copyright 2020 Division of Medical Image Computing, German Cancer Research Center (DKFZ), Heidelberg, Germany
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+
+from nnunet.training.network_training.nnUNetTrainerV2 import nnUNetTrainerV2
+from nnunet.training.loss_functions.dist_dice_loss import DistDC_and_CE_loss
+
+
+class nnUNetTrainerV2_Loss_DistDiceCE(nnUNetTrainerV2):
+    def __init__(self, plans_file, fold, output_folder=None, dataset_directory=None, batch_dice=True, stage=None,
+                 unpack_data=True, deterministic=True, fp16=False):
+        super().__init__(plans_file, fold, output_folder, dataset_directory, batch_dice, stage, unpack_data,
+                         deterministic, fp16)
+        self.loss = DistDC_and_CE_loss({'batch_dice': self.batch_dice, 'smooth': 1e-5, 'do_bg': False}, {})

--- a/nnunetv2/training/nnUNetTrainer/variants/loss/nnUNetTrainerCELoss.py
+++ b/nnunetv2/training/nnUNetTrainer/variants/loss/nnUNetTrainerCELoss.py
@@ -39,3 +39,17 @@ class nnUNetTrainerCELoss_5epochs(nnUNetTrainerCELoss):
         """used for debugging plans etc"""
         super().__init__(plans, configuration, fold, dataset_json, unpack_dataset, device)
         self.num_epochs = 5
+        
+class nnUNetTrainerCELoss_300epochs(nnUNetTrainerCELoss):
+    def __init__(
+        self,
+        plans: dict,
+        configuration: str,
+        fold: int,
+        dataset_json: dict,
+        unpack_dataset: bool = True,
+        device: torch.device = torch.device("cuda"),
+    ):
+        """used for debugging plans etc"""
+        super().__init__(plans, configuration, fold, dataset_json, unpack_dataset, device)
+        self.num_epochs = 300

--- a/nnunetv2/training/nnUNetTrainer/variants/loss/nnUNetTrainerDiceLoss.py
+++ b/nnunetv2/training/nnUNetTrainer/variants/loss/nnUNetTrainerDiceLoss.py
@@ -28,6 +28,11 @@ class nnUNetTrainerDiceLoss(nnUNetTrainer):
             loss = DeepSupervisionWrapper(loss, weights)
         return loss
 
+class nnUNetTrainerDiceLoss_300epochs(nnUNetTrainerDiceLoss):
+    def __init__(self, plans: dict, configuration: str, fold: int, dataset_json: dict, unpack_dataset: bool = True,
+                 device: torch.device = torch.device('cuda')):
+        super().__init__(plans, configuration, fold, dataset_json, unpack_dataset, device)
+        self.num_epochs = 300
 
 class nnUNetTrainerDiceCELoss_noSmooth(nnUNetTrainer):
     def _build_loss(self):

--- a/nnunetv2/training/nnUNetTrainer/variants/loss/nnUNetTrainerDistDiceLoss.py
+++ b/nnunetv2/training/nnUNetTrainer/variants/loss/nnUNetTrainerDistDiceLoss.py
@@ -1,0 +1,450 @@
+import inspect
+import multiprocessing
+import os
+import shutil
+import sys
+import warnings
+from copy import deepcopy
+from datetime import datetime
+from time import time, sleep
+from typing import Tuple, Union, List
+
+import numpy as np
+import torch
+from batchgenerators.dataloading.multi_threaded_augmenter import MultiThreadedAugmenter
+from batchgenerators.dataloading.nondet_multi_threaded_augmenter import NonDetMultiThreadedAugmenter
+from batchgenerators.dataloading.single_threaded_augmenter import SingleThreadedAugmenter
+from batchgenerators.utilities.file_and_folder_operations import join, load_json, isfile, save_json, maybe_mkdir_p
+from batchgeneratorsv2.helpers.scalar_type import RandomScalar
+from batchgeneratorsv2.transforms.base.basic_transform import BasicTransform
+from batchgeneratorsv2.transforms.intensity.brightness import MultiplicativeBrightnessTransform
+from batchgeneratorsv2.transforms.intensity.contrast import ContrastTransform, BGContrast
+from batchgeneratorsv2.transforms.intensity.gamma import GammaTransform
+from batchgeneratorsv2.transforms.intensity.gaussian_noise import GaussianNoiseTransform
+from batchgeneratorsv2.transforms.nnunet.random_binary_operator import ApplyRandomBinaryOperatorTransform
+from batchgeneratorsv2.transforms.nnunet.remove_connected_components import \
+    RemoveRandomConnectedComponentFromOneHotEncodingTransform
+from batchgeneratorsv2.transforms.nnunet.seg_to_onehot import MoveSegAsOneHotToDataTransform
+from batchgeneratorsv2.transforms.noise.gaussian_blur import GaussianBlurTransform
+from batchgeneratorsv2.transforms.spatial.low_resolution import SimulateLowResolutionTransform
+from batchgeneratorsv2.transforms.spatial.mirroring import MirrorTransform
+from batchgeneratorsv2.transforms.spatial.spatial import SpatialTransform
+from batchgeneratorsv2.transforms.utils.compose import ComposeTransforms
+from batchgeneratorsv2.transforms.utils.deep_supervision_downsampling import DownsampleSegForDSTransform
+from batchgeneratorsv2.transforms.utils.nnunet_masking import MaskImageTransform
+from batchgeneratorsv2.transforms.utils.pseudo2d import Convert3DTo2DTransform, Convert2DTo3DTransform
+from batchgeneratorsv2.transforms.utils.random import RandomTransform
+from batchgeneratorsv2.transforms.utils.remove_label import RemoveLabelTansform
+from batchgeneratorsv2.transforms.utils.seg_to_regions import ConvertSegmentationToRegionsTransform
+from torch import autocast, nn
+from torch import distributed as dist
+from torch._dynamo import OptimizedModule
+from torch.cuda import device_count
+from torch.cuda.amp import GradScaler
+from torch.nn.parallel import DistributedDataParallel as DDP
+
+from nnunetv2.configuration import ANISO_THRESHOLD, default_num_processes
+from nnunetv2.paths import nnUNet_preprocessed, nnUNet_results
+from nnunetv2.training.data_augmentation.compute_initial_patch_size import get_patch_size
+from nnunetv2.training.dataloading.data_loader_2d import nnUNetDataLoader2D
+from nnunetv2.training.dataloading.data_loader_3d_dist import nnUNetDataLoader3DDist
+from nnunetv2.training.logging.nnunet_logger import nnUNetLogger
+from nnunetv2.training.loss.compound_losses import DC_and_CE_loss, DC_and_BCE_loss
+from nnunetv2.training.loss.deep_supervision import DeepSupervisionWrapper
+from nnunetv2.training.loss.dice import get_tp_fp_fn_tn, MemoryEfficientSoftDiceLoss
+from nnunetv2.training.loss.dist_losses import MemoryEfficientDistDiceLoss
+from nnunetv2.utilities.default_n_proc_DA import get_allowed_n_proc_DA
+from nnunetv2.utilities.helpers import empty_cache, dummy_context
+from nnunetv2.training.loss.compound_losses import DC_and_BCE_loss, DC_and_CE_loss
+from nnunetv2.training.loss.deep_supervision import DeepSupervisionWrapper
+from nnunetv2.training.loss.dice import MemoryEfficientSoftDiceLoss
+from nnunetv2.training.nnUNetTrainer.nnUNetTrainer import nnUNetTrainer
+from nnunetv2.utilities.helpers import softmax_helper_dim1
+from nnunetv2.training.dataloading.distance_transform_dataset import DistanceTransformDataset
+from nnunetv2.training.data_augmentation.custom_transforms.distance_map_augmentation import *
+
+
+
+class nnUNetTrainerDistDiceLoss(nnUNetTrainer):
+    def __init__(self, plans: dict, configuration: str, fold: int, dataset_json: dict, unpack_dataset: bool = True,
+                 device: torch.device = torch.device('cuda')):
+        super().__init__(plans, configuration, fold, dataset_json, unpack_dataset, device)
+        self.dataset_class = DistanceTransformDataset  # Use the custom dataset class
+        
+    def _build_loss(self):
+        loss = MemoryEfficientDistDiceLoss(**{'batch_dice': self.configuration_manager.batch_dice,
+                                              'do_bg': self.label_manager.has_regions, 'smooth': 1e-5, 'ddp': self.is_ddp},
+                                           apply_nonlin=torch.sigmoid if self.label_manager.has_regions else softmax_helper_dim1)
+
+        if self.enable_deep_supervision:
+            deep_supervision_scales = self._get_deep_supervision_scales()
+
+            # we give each output a weight which decreases exponentially (division by 2) as the resolution decreases
+            # this gives higher resolution outputs more weight in the loss
+            weights = np.array([1 / (2 ** i) for i in range(len(deep_supervision_scales))])
+            weights[-1] = 0
+
+            # we don't use the lowest 2 outputs. Normalize weights so that they sum to 1
+            weights = weights / weights.sum()
+            # now wrap the loss
+            loss = DeepSupervisionWrapper(loss, weights)
+        return loss
+
+    def get_tr_and_val_datasets(self):
+        # Create dataset split
+        tr_keys, val_keys = self.do_split()
+
+        # Load the datasets for training and validation using DistanceTransformDataset
+        dataset_tr = self.dataset_class(
+            folder=self.preprocessed_dataset_folder,
+            case_identifiers=tr_keys,
+            folder_with_segs_from_previous_stage=self.folder_with_segs_from_previous_stage,
+            num_images_properties_loading_threshold=0
+        )
+        dataset_val = self.dataset_class(
+            folder=self.preprocessed_dataset_folder,
+            case_identifiers=val_keys,
+            folder_with_segs_from_previous_stage=self.folder_with_segs_from_previous_stage,
+            num_images_properties_loading_threshold=0
+        )
+        return dataset_tr, dataset_val
+
+    def get_dataloaders(self):
+        patch_size = self.configuration_manager.patch_size
+        dim = len(patch_size)
+
+        # needed for deep supervision: how much do we need to downscale the segmentation targets for the different
+        # outputs?
+
+        deep_supervision_scales = self._get_deep_supervision_scales()
+
+        (
+            rotation_for_DA,
+            do_dummy_2d_data_aug,
+            initial_patch_size,
+            mirror_axes,
+        ) = self.configure_rotation_dummyDA_mirroring_and_inital_patch_size()
+
+        # training pipeline
+        tr_transforms = self.get_training_transforms(
+            patch_size, rotation_for_DA, deep_supervision_scales, mirror_axes, do_dummy_2d_data_aug,
+            use_mask_for_norm=self.configuration_manager.use_mask_for_norm,
+            is_cascaded=self.is_cascaded, foreground_labels=self.label_manager.foreground_labels,
+            regions=self.label_manager.foreground_regions if self.label_manager.has_regions else None,
+            ignore_label=self.label_manager.ignore_label)
+
+        # validation pipeline
+        val_transforms = self.get_validation_transforms(deep_supervision_scales,
+                                                        is_cascaded=self.is_cascaded,
+                                                        foreground_labels=self.label_manager.foreground_labels,
+                                                        regions=self.label_manager.foreground_regions if
+                                                        self.label_manager.has_regions else None,
+                                                        ignore_label=self.label_manager.ignore_label)
+
+        dataset_tr, dataset_val = self.get_tr_and_val_datasets()
+
+        if dim == 2:
+            print("Distance transforms for 2D images has not been implemented yet. Will default to regular 2D DataLoaders for now.")
+            # TODO: nnUNetDataLoader2DDist
+            dl_tr = nnUNetDataLoader2D(dataset_tr, self.batch_size,
+                                       initial_patch_size,
+                                       self.configuration_manager.patch_size,
+                                       self.label_manager,
+                                       oversample_foreground_percent=self.oversample_foreground_percent,
+                                       sampling_probabilities=None, pad_sides=None, transforms=tr_transforms)
+            dl_val = nnUNetDataLoader2D(dataset_val, self.batch_size,
+                                        self.configuration_manager.patch_size,
+                                        self.configuration_manager.patch_size,
+                                        self.label_manager,
+                                        oversample_foreground_percent=self.oversample_foreground_percent,
+                                        sampling_probabilities=None, pad_sides=None, transforms=val_transforms)
+        else:
+            dl_tr = nnUNetDataLoader3DDist(dataset_tr, self.batch_size,
+                                       initial_patch_size,
+                                       self.configuration_manager.patch_size,
+                                       self.label_manager,
+                                       oversample_foreground_percent=self.oversample_foreground_percent,
+                                       sampling_probabilities=None, pad_sides=None, transforms=tr_transforms)
+            dl_val = nnUNetDataLoader3DDist(dataset_val, self.batch_size,
+                                        self.configuration_manager.patch_size,
+                                        self.configuration_manager.patch_size,
+                                        self.label_manager,
+                                        oversample_foreground_percent=self.oversample_foreground_percent,
+                                        sampling_probabilities=None, pad_sides=None, transforms=val_transforms)
+
+        # allowed_num_processes = get_allowed_n_proc_DA()
+        allowed_num_processes = 0
+        if allowed_num_processes == 0:
+            mt_gen_train = SingleThreadedAugmenter(dl_tr, None)
+            mt_gen_val = SingleThreadedAugmenter(dl_val, None)
+        else:
+            mt_gen_train = NonDetMultiThreadedAugmenter(data_loader=dl_tr, transform=None,
+                                                        num_processes=allowed_num_processes,
+                                                        num_cached=max(6, allowed_num_processes // 2), seeds=None,
+                                                        pin_memory=self.device.type == 'cuda', wait_time=0.002)
+            mt_gen_val = NonDetMultiThreadedAugmenter(data_loader=dl_val,
+                                                      transform=None, num_processes=max(1, allowed_num_processes // 2),
+                                                      num_cached=max(3, allowed_num_processes // 4), seeds=None,
+                                                      pin_memory=self.device.type == 'cuda',
+                                                      wait_time=0.002)
+        # # let's get this party started
+        _ = next(mt_gen_train)
+        _ = next(mt_gen_val)
+        return mt_gen_train, mt_gen_val
+
+
+    @staticmethod
+    # TODO: Distance map transforms
+    def get_training_transforms(
+            patch_size: Union[np.ndarray, Tuple[int]],
+            rotation_for_DA: RandomScalar,
+            deep_supervision_scales: Union[List, Tuple, None],
+            mirror_axes: Tuple[int, ...],
+            do_dummy_2d_data_aug: bool,
+            use_mask_for_norm: List[bool] = None,
+            is_cascaded: bool = False,
+            foreground_labels: Union[Tuple[int, ...], List[int]] = None,
+            regions: List[Union[List[int], Tuple[int, ...], int]] = None,
+            ignore_label: int = None,
+    ) -> BasicTransform:
+        transforms = []
+        if do_dummy_2d_data_aug:
+            ignore_axes = (0,)
+            transforms.append(Convert3DTo2DDistTransform())
+            patch_size_spatial = patch_size[1:]
+        else:
+            patch_size_spatial = patch_size
+            ignore_axes = None
+        transforms.append(
+            SpatialDistTransform(
+                patch_size_spatial, patch_center_dist_from_border=0, random_crop=False, p_elastic_deform=0,
+                p_rotation=0.2,
+                rotation=rotation_for_DA, p_scaling=0.2, scaling=(0.7, 1.4), p_synchronize_scaling_across_axes=1,
+                bg_style_seg_sampling=False  # , mode_seg='nearest'
+            )
+        )
+
+        if do_dummy_2d_data_aug:
+            transforms.append(Convert2DTo3DDistTransform())
+
+        transforms.append(RandomTransform(
+            GaussianNoiseTransform(
+                noise_variance=(0, 0.1),
+                p_per_channel=1,
+                synchronize_channels=True
+            ), apply_probability=0.1
+        ))
+        transforms.append(RandomTransform(
+            GaussianBlurTransform(
+                blur_sigma=(0.5, 1.),
+                synchronize_channels=False,
+                synchronize_axes=False,
+                p_per_channel=0.5, benchmark=True
+            ), apply_probability=0.2
+        ))
+        transforms.append(RandomTransform(
+            MultiplicativeBrightnessTransform(
+                multiplier_range=BGContrast((0.75, 1.25)),
+                synchronize_channels=False,
+                p_per_channel=1
+            ), apply_probability=0.15
+        ))
+        transforms.append(RandomTransform(
+            ContrastTransform(
+                contrast_range=BGContrast((0.75, 1.25)),
+                preserve_range=True,
+                synchronize_channels=False,
+                p_per_channel=1
+            ), apply_probability=0.15
+        ))
+        transforms.append(RandomTransform(
+            SimulateLowResolutionTransform(
+                scale=(0.5, 1),
+                synchronize_channels=False,
+                synchronize_axes=True,
+                ignore_axes=ignore_axes,
+                allowed_channels=None,
+                p_per_channel=0.5
+            ), apply_probability=0.25
+        ))
+        transforms.append(RandomTransform(
+            GammaTransform(
+                gamma=BGContrast((0.7, 1.5)),
+                p_invert_image=1,
+                synchronize_channels=False,
+                p_per_channel=1,
+                p_retain_stats=1
+            ), apply_probability=0.1
+        ))
+        transforms.append(RandomTransform(
+            GammaTransform(
+                gamma=BGContrast((0.7, 1.5)),
+                p_invert_image=0,
+                synchronize_channels=False,
+                p_per_channel=1,
+                p_retain_stats=1
+            ), apply_probability=0.3
+        ))
+        if mirror_axes is not None and len(mirror_axes) > 0:
+            transforms.append(
+                MirrorDistTransform(
+                    allowed_axes=mirror_axes
+                )
+            )
+
+        if use_mask_for_norm is not None and any(use_mask_for_norm):
+            transforms.append(MaskImageTransform(
+                apply_to_channels=[i for i in range(len(use_mask_for_norm)) if use_mask_for_norm[i]],
+                channel_idx_in_seg=0,
+                set_outside_to=0,
+            ))
+
+        transforms.append(
+            RemoveLabelTansform(-1, 0)
+        )
+        if is_cascaded:
+            assert foreground_labels is not None, 'We need foreground_labels for cascade augmentations'
+            transforms.append(
+                MoveSegAsOneHotToDataTransform(
+                    source_channel_idx=1,
+                    all_labels=foreground_labels,
+                    remove_channel_from_source=True
+                )
+            )
+            transforms.append(
+                RandomTransform(
+                    ApplyRandomBinaryOperatorTransform(
+                        channel_idx=list(range(-len(foreground_labels), 0)),
+                        strel_size=(1, 8),
+                        p_per_label=1
+                    ), apply_probability=0.4
+                )
+            )
+            transforms.append(
+                RandomTransform(
+                    RemoveRandomConnectedComponentFromOneHotEncodingTransform(
+                        channel_idx=list(range(-len(foreground_labels), 0)),
+                        fill_with_other_class_p=0,
+                        dont_do_if_covers_more_than_x_percent=0.15,
+                        p_per_label=1
+                    ), apply_probability=0.2
+                )
+            )
+
+        if regions is not None:
+            # the ignore label must also be converted
+            transforms.append(
+                ConvertSegmentationToRegionsTransform(
+                    regions=list(regions) + [ignore_label] if ignore_label is not None else regions,
+                    channel_in_seg=0
+                )
+            )
+
+        if deep_supervision_scales is not None:
+            transforms.append(DownsampleSegForDSDistTransform(ds_scales=deep_supervision_scales))
+
+        return ComposeTransforms(transforms)
+
+    @staticmethod
+    def get_validation_transforms(
+            deep_supervision_scales: Union[List, Tuple, None],
+            is_cascaded: bool = False,
+            foreground_labels: Union[Tuple[int, ...], List[int]] = None,
+            regions: List[Union[List[int], Tuple[int, ...], int]] = None,
+            ignore_label: int = None,
+    ) -> BasicTransform:
+        transforms = []
+        transforms.append(
+            RemoveLabelTansform(-1, 0)
+        )
+
+        if is_cascaded:
+            transforms.append(
+                MoveSegAsOneHotToDataTransform(
+                    source_channel_idx=1,
+                    all_labels=foreground_labels,
+                    remove_channel_from_source=True
+                )
+            )
+
+        if regions is not None:
+            # the ignore label must also be converted
+            transforms.append(
+                ConvertSegmentationToRegionsTransform(
+                    regions=list(regions) + [ignore_label] if ignore_label is not None else regions,
+                    channel_in_seg=0
+                )
+            )
+
+        if deep_supervision_scales is not None:
+            transforms.append(DownsampleSegForDSTransform(ds_scales=deep_supervision_scales))
+        return ComposeTransforms(transforms)
+
+
+    def train_step(self, batch: dict) -> dict:
+        data = batch['data']
+        target = batch['target']
+        dist_map = batch['distance_map']
+
+        data = data.to(self.device, non_blocking=True)
+        if isinstance(target, list):
+            target = [i.to(self.device, non_blocking=True) for i in target]
+        else:
+            target = target.to(self.device, non_blocking=True)
+        if isinstance(dist_map, list):
+            dist_map = [i.to(self.device, non_blocking=True) for i in dist_map]
+        else:
+            dist_map = dist_map.to(self.device, non_blocking=True)
+
+        self.optimizer.zero_grad(set_to_none=True)
+        # Autocast can be annoying
+        # If the device_type is 'cpu' then it's slow as heck and needs to be disabled.
+        # If the device_type is 'mps' then it will complain that mps is not implemented, even if enabled=False is set. Whyyyyyyy. (this is why we don't make use of enabled=False)
+        # So autocast will only be active if we have a cuda device.
+        with autocast(self.device.type, enabled=True) if self.device.type == 'cuda' else dummy_context():
+            output = self.network(data)
+            # del data
+            l = self.loss(output, target, dist_map)
+
+        if self.grad_scaler is not None:
+            self.grad_scaler.scale(l).backward()
+            self.grad_scaler.unscale_(self.optimizer)
+            torch.nn.utils.clip_grad_norm_(self.network.parameters(), 12)
+            self.grad_scaler.step(self.optimizer)
+            self.grad_scaler.update()
+        else:
+            l.backward()
+            torch.nn.utils.clip_grad_norm_(self.network.parameters(), 12)
+            self.optimizer.step()
+        return {'loss': l.detach().cpu().numpy()}
+
+
+class nnUNetTrainerDistDiceCELoss(nnUNetTrainer):
+    def _build_loss(self):
+        # TODO: DistDC_and_BCE_loss, DistDC_and_CE_loss
+        if self.label_manager.has_regions:
+            loss = DC_and_BCE_loss({},
+                                   {'batch_dice': self.configuration_manager.batch_dice,
+                                    'do_bg': True, 'smooth': 1e-5, 'ddp': self.is_ddp},
+                                   use_ignore_label=self.label_manager.ignore_label is not None,
+                                   dice_class=MemoryEfficientSoftDiceLoss)
+        else:
+            loss = DC_and_CE_loss({'batch_dice': self.configuration_manager.batch_dice,
+                                   'smooth': 1e-5, 'do_bg': False, 'ddp': self.is_ddp}, {}, weight_ce=1, weight_dice=1,
+                                  ignore_label=self.label_manager.ignore_label,
+                                  dice_class=MemoryEfficientSoftDiceLoss)
+
+        if self.enable_deep_supervision:
+            deep_supervision_scales = self._get_deep_supervision_scales()
+
+            # we give each output a weight which decreases exponentially (division by 2) as the resolution decreases
+            # this gives higher resolution outputs more weight in the loss
+            weights = np.array([1 / (2 ** i) for i in range(len(deep_supervision_scales))])
+            weights[-1] = 0
+
+            # we don't use the lowest 2 outputs. Normalize weights so that they sum to 1
+            weights = weights / weights.sum()
+            # now wrap the loss
+            loss = DeepSupervisionWrapper(loss, weights)
+        return loss
+

--- a/nnunetv2/training/nnUNetTrainer/variants/loss/nnUNetTrainerFocalLoss.py
+++ b/nnunetv2/training/nnUNetTrainer/variants/loss/nnUNetTrainerFocalLoss.py
@@ -1,0 +1,76 @@
+import torch
+from nnunetv2.training.loss.deep_supervision import DeepSupervisionWrapper
+from nnunetv2.training.nnUNetTrainer.nnUNetTrainer import nnUNetTrainer
+from nnunetv2.training.loss.focal_loss import FocalLoss
+from nnunetv2.training.loss.compound_losses import DC_and_Focal_loss
+from nnunetv2.training.loss.dice import SoftDiceLoss, MemoryEfficientSoftDiceLoss
+import numpy as np
+
+class nnUNetTrainerFocalLoss(nnUNetTrainer):
+    def _build_loss(self):
+        assert not self.label_manager.has_regions, "regions not supported by this trainer"
+        loss = FocalLoss(**{'alpha': 1, 'gamma': 2, 'reduction': 'mean'})
+        # we give each output a weight which decreases exponentially (division by 2) as the resolution decreases
+        # this gives higher resolution outputs more weight in the loss
+        if self.enable_deep_supervision:
+            deep_supervision_scales = self._get_deep_supervision_scales()
+            weights = np.array([1 / (2**i) for i in range(len(deep_supervision_scales))])
+            weights[-1] = 0
+
+            # we don't use the lowest 2 outputs. Normalize weights so that they sum to 1
+            weights = weights / weights.sum()
+            # now wrap the loss
+            loss = DeepSupervisionWrapper(loss, weights)
+
+        return loss
+
+class nnUNetTrainerFocalLoss_300epochs(nnUNetTrainerFocalLoss):
+    def __init__(
+        self,
+        plans: dict,
+        configuration: str,
+        fold: int,
+        dataset_json: dict,
+        unpack_dataset: bool = True,
+        device: torch.device = torch.device("cuda"),
+    ):
+        """used for debugging plans etc"""
+        super().__init__(plans, configuration, fold, dataset_json, unpack_dataset, device)
+        self.num_epochs = 300
+
+
+class nnUNetTrainerDiceFocalLoss(nnUNetTrainer):
+    def _build_loss(self):
+        assert not self.label_manager.has_regions, "regions not supported by this trainer"
+        loss = DC_and_Focal_loss({'batch_dice': self.configuration_manager.batch_dice,
+                                  'smooth': 1e-5, 'do_bg': False, 'ddp': self.is_ddp},
+                                 {'alpha': 1, 'gamma': 2, 'reduction': 'mean'},
+                                  weight_focal=1, weight_dice=1,
+                                  ignore_label=self.label_manager.ignore_label, dice_class=MemoryEfficientSoftDiceLoss)
+        # we give each output a weight which decreases exponentially (division by 2) as the resolution decreases
+        # this gives higher resolution outputs more weight in the loss
+        if self.enable_deep_supervision:
+            deep_supervision_scales = self._get_deep_supervision_scales()
+            weights = np.array([1 / (2**i) for i in range(len(deep_supervision_scales))])
+            weights[-1] = 0
+
+            # we don't use the lowest 2 outputs. Normalize weights so that they sum to 1
+            weights = weights / weights.sum()
+            # now wrap the loss
+            loss = DeepSupervisionWrapper(loss, weights)
+
+        return loss
+
+class nnUNetTrainerDiceFocalLoss_300epochs(nnUNetTrainerDiceFocalLoss):
+    def __init__(
+        self,
+        plans: dict,
+        configuration: str,
+        fold: int,
+        dataset_json: dict,
+        unpack_dataset: bool = True,
+        device: torch.device = torch.device("cuda"),
+    ):
+        """used for debugging plans etc"""
+        super().__init__(plans, configuration, fold, dataset_json, unpack_dataset, device)
+        self.num_epochs = 300

--- a/nnunetv2/training/nnUNetTrainer/variants/training_length/nnUNetTrainer_Xepochs.py
+++ b/nnunetv2/training/nnUNetTrainer/variants/training_length/nnUNetTrainer_Xepochs.py
@@ -54,6 +54,12 @@ class nnUNetTrainer_250epochs(nnUNetTrainer):
         super().__init__(plans, configuration, fold, dataset_json, unpack_dataset, device)
         self.num_epochs = 250
 
+class nnUNetTrainer_300epochs(nnUNetTrainer):
+    def __init__(self, plans: dict, configuration: str, fold: int, dataset_json: dict, unpack_dataset: bool = True,
+                 device: torch.device = torch.device('cuda')):
+        super().__init__(plans, configuration, fold, dataset_json, unpack_dataset, device)
+        self.num_epochs = 300
+
 
 class nnUNetTrainer_500epochs(nnUNetTrainer):
     def __init__(self, plans: dict, configuration: str, fold: int, dataset_json: dict, unpack_dataset: bool = True,


### PR DESCRIPTION
Added a FocalLoss class that also works in compound loss functions. nnUNet also currently does not have a framework for loading in distance maps that were calculated offline. I propose a framework of calculating distance maps from segmentations in the `preprocessed` folder designated by the `plans` json. These maps are saved as `<case_num>_dist.npy`. In doing so, the `plans` json does not need to necessarily be modified. I have also made a Dataset class and a DataLoader class that is able to load these distance maps during training. Furthermore, I have added custom transform classes that transform distance maps commensurately with image data and segmentations. To make this work, I submitted a pull request in batchgeneratorsv2 to modify the BasicTransform class slightly.