### PR TITLE
Flexible number of epochs

### DIFF
--- a/nnunetv2/training/nnUNetTrainer/nnUNetTrainer.py
+++ b/nnunetv2/training/nnUNetTrainer/nnUNetTrainer.py
@@ -149,7 +149,7 @@ class nnUNetTrainer(object):
         self.oversample_foreground_percent = 0.33
         self.num_iterations_per_epoch = 250
         self.num_val_iterations_per_epoch = 50
-        self.num_epochs = 1000
+        self.num_epochs = 1000 if "num_epochs" not in os.environ else int(os.environ["num_epochs"])
         self.current_epoch = 0
         self.enable_deep_supervision = True
 


### PR DESCRIPTION
Allows to limit the number of epoch over the os environment variable `num_epochs`.