### PR TITLE
Override Torch 2.6 default weights_only=True for nnUNetV1

### DIFF
--- a/nnunet/training/network_training/network_trainer.py
+++ b/nnunet/training/network_training/network_trainer.py
@@ -317,7 +317,7 @@ class NetworkTrainer(object):
         if not self.was_initialized:
             self.initialize(train)
         # saved_model = torch.load(fname, map_location=torch.device('cuda', torch.cuda.current_device()))
-        saved_model = torch.load(fname, map_location=torch.device('cpu'))
+        saved_model = torch.load(fname, map_location=torch.device('cpu'), weights_only=False)
         self.load_checkpoint_ram(saved_model, train)
 
     @abstractmethod


### PR DESCRIPTION
In Torch 2.6, weights_only=True is now the default when loading weights. This update explicitly sets weights_only=False for nnUNetV1 to ensure the correct behavior.