### PR TITLE
Bugfix - predict_from_data_iterator tensor serialization issue

### DIFF
--- a/nnunetv2/inference/predict_from_raw_data.py
+++ b/nnunetv2/inference/predict_from_raw_data.py
@@ -385,7 +385,7 @@ class nnUNetPredictor(object):
                     proceed = not check_workers_alive_and_busy(export_pool, worker_list, r, allowed_num_queued=2)
 
                 # convert to numpy to prevent uncatchable memory alignment errors from multiprocessing serialization of torch tensors
-                prediction = self.predict_logits_from_preprocessed_data(data).cpu().detach().numpy().copy()
+                prediction = self.predict_logits_from_preprocessed_data(data).cpu().detach().numpy()
 
                 if ofile is not None:
                     print('sending off prediction to background worker for resampling and export')

--- a/nnunetv2/inference/predict_from_raw_data.py
+++ b/nnunetv2/inference/predict_from_raw_data.py
@@ -385,7 +385,7 @@ class nnUNetPredictor(object):
                     proceed = not check_workers_alive_and_busy(export_pool, worker_list, r, allowed_num_queued=2)
 
                 # convert to numpy to prevent uncatchable memory alignment errors from multiprocessing serialization of torch tensors
-                prediction = self.predict_logits_from_preprocessed_data(data).cpu().detach().numpy()
+                prediction = self.predict_logits_from_preprocessed_data(data).cpu().detach().numpy().copy()
 
                 if ofile is not None:
                     print('sending off prediction to background worker for resampling and export')

--- a/nnunetv2/inference/predict_from_raw_data.py
+++ b/nnunetv2/inference/predict_from_raw_data.py
@@ -377,19 +377,17 @@ class nnUNetPredictor(object):
 
                 properties = preprocessed['data_properties']
 
-                # let's not get into a runaway situation where the GPU predicts so fast that the disk has to b swamped with
+                # let's not get into a runaway situation where the GPU predicts so fast that the disk has to be swamped with
                 # npy files
                 proceed = not check_workers_alive_and_busy(export_pool, worker_list, r, allowed_num_queued=2)
                 while not proceed:
                     sleep(0.1)
                     proceed = not check_workers_alive_and_busy(export_pool, worker_list, r, allowed_num_queued=2)
 
-                prediction = self.predict_logits_from_preprocessed_data(data).cpu()
+                # convert to numpy to prevent uncatchable memory alignment errors from multiprocessing serialization of torch tensors
+                prediction = self.predict_logits_from_preprocessed_data(data).cpu().detach().numpy()
 
                 if ofile is not None:
-                    # this needs to go into background processes
-                    # export_prediction_from_logits(prediction, properties, self.configuration_manager, self.plans_manager,
-                    #                               self.dataset_json, ofile, save_probabilities)
                     print('sending off prediction to background worker for resampling and export')
                     r.append(
                         export_pool.starmap_async(
@@ -399,12 +397,6 @@ class nnUNetPredictor(object):
                         )
                     )
                 else:
-                    # convert_predicted_logits_to_segmentation_with_correct_shape(
-                    #             prediction, self.plans_manager,
-                    #              self.configuration_manager, self.label_manager,
-                    #              properties,
-                    #              save_probabilities)
-
                     print('sending off prediction to background worker for resampling')
                     r.append(
                         export_pool.starmap_async(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nnunetv2"
-version = "2.6.0"
+version = "2.6.1"
 requires-python = ">=3.10"
 description = "nnU-Net is a framework for out-of-the box image segmentation."
 readme = "readme.md"


### PR DESCRIPTION
I have encountered several fatal SIGBUS errors using TotalSegmentator which uses nnUnetV2 under the hood. 
The errors occurred when running TotalSegmentator on large inputs.
After some digging, I was able to boil the issue down to the predict_from_data_iterator function of nnUNet, which passes the (in my case quite large) prediction result tensors to worker processes. For this step, the tensors need to be serialized, which apparently can cause memory alignment issues and trigger SIGBUS errors.
I noticed the error would disappear if I removed the multiprocessing logic, but numpy arrays seem much more stable regarding serialization and fixed the SIGBUS errors even with multiprocessing, hence this PR.

Here's a summary from Claude AI with slightly more details:

# SIGBUS Error in PyTorch Multiprocessing: Claude (AI) Summary

The SIGBUS error occurred when passing PyTorch tensors between processes via multiprocessing. Here's what happened:

## Root Cause

In the original function, we were serializing PyTorch tensors directly for multiprocessing:

```python
# This line produces a PyTorch tensor
prediction = self.predict_logits_from_preprocessed_data(data).cpu()

# Problematic: Passing PyTorch tensor directly to worker process
future = executor.submit(
    export_prediction_from_logits,
    prediction, properties, self.configuration_manager, 
    # ...other arguments...
)
```

When PyTorch tensors are serialized and sent to child processes, their complex memory layout isn't perfectly preserved. This leads to memory alignment issues that trigger SIGBUS errors.

## Solution

Converting the tensor to a NumPy array before passing it to the worker process:

```python
# Convert to NumPy for safer serialization
prediction = self.predict_logits_from_preprocessed_data(data).cpu().numpy()

# Now safe: Passing NumPy array to worker process
future = executor.submit(
    export_prediction_from_logits,
    prediction, properties, self.configuration_manager, 
    # ...other arguments...
)
```

This fixes the issue by:
- Converting the tensor to a simpler NumPy array format
- Creating a copy with proper memory alignment
- Eliminating PyTorch-specific memory structures that don't serialize well

The SIGBUS error only happens with multiprocessing because tensors must cross process boundaries through serialization/deserialization, which can't perfectly preserve their memory layout.
