### PR TITLE
Remove dicom2nifti since it isn't used

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,6 @@ dependencies = [
     "acvl-utils>=0.2.3,<0.3",  # 0.3 may bring breaking changes. Careful!
     "dynamic-network-architectures>=0.3.1,<0.4",  # 0.3.1 and lower are supported, 0.4 may have breaking changes. Let's be careful here
     "tqdm",
-    "dicom2nifti",
     "scipy",
     "batchgenerators>=0.25.1",
     "numpy>=1.24",


### PR DESCRIPTION
Closes #2430

I can't find anywhere that uses the `dicom2nifti` library and it is causing a fatal FIPS error on FIPS enabled machines. Removing the dependency would resolve the issue.