### PR TITLE
Mlflow logging, checkpointing, and resuming

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -47,7 +47,7 @@ checkpointing_bucket:
   type: str
   description: "S3 bucket name where the checkpoints are being written to."
 mlflow_run_id:
-  value: "9632cc50bc7b47e68cdd10e89d338506"
+  value: ""
   type: str
   description: "Run id of MLFlow to identify the checkpoint to resume from."
 aws_region:

--- a/config.yaml
+++ b/config.yaml
@@ -34,4 +34,9 @@ enable_deep_supervision:
   value: true
   type: bool
   description: "Whether to enable deep supervision"
-
+experiment_name:
+  value: "nnUnet-default"
+  type: str
+  description: "Name of the MLFlow experiment name."
+tracking_uri:
+  value: "https://mlflow.spectomedical.com"

--- a/config.yaml
+++ b/config.yaml
@@ -23,7 +23,7 @@ num_val_iterations_per_epoch:
   type: int
   description: "Number of validation iterations per epoch"
 num_epochs:
-  value: 150
+  value: 5
   type: int
   description: "Total number of epochs"
 current_epoch:
@@ -47,7 +47,7 @@ checkpointing_bucket:
   type: str
   description: "S3 bucket name where the checkpoints are being written to."
 mlflow_run_id:
-  value: "e0074c4a92b349948e222f32cb5ab77d"
+  value: "9632cc50bc7b47e68cdd10e89d338506"
   type: str
   description: "Run id of MLFlow to identify the checkpoint to resume from."
 aws_region:

--- a/config.yaml
+++ b/config.yaml
@@ -46,6 +46,10 @@ checkpointing_bucket:
   value: "specto-ai-ts-checkpoints"
   type: str
   description: "S3 bucket name where the checkpoints are being written to."
+mlflow_run_id:
+  value: "e0074c4a92b349948e222f32cb5ab77d"
+  type: str
+  description: "Run id of MLFlow to identify the checkpoint to resume from."
 aws_region:
   value: "eu-central-1"
   type: str

--- a/config.yaml
+++ b/config.yaml
@@ -42,3 +42,11 @@ tracking_uri:
   value: "https://mlflow.spectomedical.com"
   type: str
   description: "Address of the MLFlow server"
+checkpointing_bucket:
+  value: "specto-ai-ts-checkpoints"
+  type: str
+  description: "S3 bucket name where the checkpoints are being written to."
+aws_region:
+  value: "eu-central-1"
+  type: str
+  description: "AWS region to select the respective S3 endpoint."

--- a/config.yaml
+++ b/config.yaml
@@ -40,3 +40,5 @@ experiment_name:
   description: "Name of the MLFlow experiment name."
 tracking_uri:
   value: "https://mlflow.spectomedical.com"
+  type: str
+  description: "Address of the MLFlow server"

--- a/nnunetv2/run/run_training.py
+++ b/nnunetv2/run/run_training.py
@@ -99,9 +99,9 @@ def load_checkpoint_from_s3(nnunet_trainer: nnUNetTrainer, final: bool = False):
                         nnunet_trainer.mlflow_run_id
                     )
                     return True
-            nnunet_trainer.print_to_log_file(f"WARNING: could not find the checkpoint associated with"
-                                             f"mlflow_run_id: {nnunet_trainer.mlflow_run_id} on"
-                                             f"bucket: {nnunet_trainer.checkpointing_bucket} with"
+            nnunet_trainer.print_to_log_file(f"WARNING: could not find the checkpoint associated with "
+                                             f"mlflow_run_id: {nnunet_trainer.mlflow_run_id} on "
+                                             f"bucket: {nnunet_trainer.checkpointing_bucket} with "
                                              f"object name: {object_name}.")
     return False
 
@@ -335,8 +335,8 @@ def run_training_entry(testing: bool = False):
                     help="Use this to set the device the training should run with. Available options are 'cuda' "
                          "(GPU), 'cpu' (CPU) and 'mps' (Apple M1/M2). Do NOT use this to set which GPU ID! "
                          "Use CUDA_VISIBLE_DEVICES=X nnUNetv2_train [...] instead!")
-    parser.add_argument('--mlflow_run_id', type=str, required=False, default="",
-                        help='Run ID of MLFlow experiment to resume training or validate only.')
+    #parser.add_argument('--mlflow_run_id', type=str, required=False, default="",
+    #                    help='Run ID of MLFlow experiment to resume training or validate only.')
 
     # ---- Added as of improved argument passing requirement ----
     # Parse known args first to check for config file

--- a/nnunetv2/tests/unit_tests/test_checkpointing.py
+++ b/nnunetv2/tests/unit_tests/test_checkpointing.py
@@ -1,0 +1,91 @@
+import unittest
+import boto3
+from botocore.exceptions import ClientError
+import io
+import os
+import sys
+import torch
+
+# Move up three levels
+parent_dir = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+sys.path.insert(0, parent_dir)
+
+# Import the function to be tested
+from utilities.checkpointing import save_checkpoint_s3, load_checkpoint_s3
+
+
+class TestSaveCheckpointS3RealConnection(unittest.TestCase):
+    def setUp(self):
+        """Set up an S3 bucket, deleting it first if it already exists."""
+        self.s3 = boto3.resource("s3", region_name=os.environ.get("AWS_REGION"))
+        self.bucket_name = "checkpointing-test-bucket"
+
+        # Check if the bucket exists and delete it if necessary
+        bucket = self.s3.Bucket(self.bucket_name)
+        try:
+            if bucket.creation_date:
+                # Delete all objects in the bucket
+                bucket.objects.all().delete()
+                # Delete the bucket itself
+                bucket.delete()
+        except ClientError as e:
+            error_code = e.response["Error"]["Code"]
+            if error_code != "404":
+                print(f"Unexpected error when checking or deleting bucket: {e}")
+                raise
+
+        # Create a new bucket
+        self.s3.create_bucket(
+            Bucket=self.bucket_name,
+            CreateBucketConfiguration={
+                "LocationConstraint": os.environ.get("AWS_REGION")
+            }
+        )
+
+    def tearDown(self):
+        """Clean up the S3 bucket after tests."""
+        bucket = self.s3.Bucket(self.bucket_name)
+        try:
+            # Delete all objects in the bucket
+            bucket.objects.all().delete()
+            # Delete the bucket itself
+            bucket.delete()
+        except ClientError as e:
+            print(f"Error during teardown: {e}")
+            raise
+
+    def test_save_and_load_checkpoint_s3(self):
+        # Mock inputs
+        state_dict = {"layer1.weight": torch.randn(10, 10)}  # Example state_dict
+        epoch = 37
+        mlflow_run_id = "12345"
+
+        # Call the function
+        checkpoint_path = save_checkpoint_s3(state_dict, epoch, self.bucket_name, mlflow_run_id, os.getenv("AWS_REGION"))
+
+        # Verify the result
+        expected_path = f"checkpoints/run_{mlflow_run_id}/epoch_{epoch}.pt"
+        self.assertTrue(expected_path in checkpoint_path)
+
+        # Verify that the object exists in the real S3 bucket
+        obj = self.s3.Object(self.bucket_name, f"checkpoints/run_{mlflow_run_id}/epoch_{epoch}.pt")
+        obj_body = obj.get()["Body"].read()
+
+        # Verify that the object content matches the serialized state_dict
+        buffer = io.BytesIO(obj_body)
+        loaded_state_dict = torch.load(buffer)
+        self.assertEqual(state_dict.keys(), loaded_state_dict.keys())
+        for key in state_dict:
+            self.assertTrue(torch.equal(state_dict[key], loaded_state_dict[key]))
+
+        # Load checkpoint from S3
+        loaded_state_dict = load_checkpoint_s3(epoch, self.bucket_name, mlflow_run_id)
+
+        # Verify that the loaded state_dict matches the original one
+        self.assertEqual(state_dict.keys(), loaded_state_dict.keys())
+        for key in state_dict:
+            self.assertTrue(torch.equal(state_dict[key], loaded_state_dict[key]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/nnunetv2/tests/unit_tests/test_checkpointing.py
+++ b/nnunetv2/tests/unit_tests/test_checkpointing.py
@@ -6,12 +6,8 @@ import os
 import sys
 import torch
 
-# Move up three levels
-parent_dir = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
-sys.path.insert(0, parent_dir)
-
 # Import the function to be tested
-from utilities.checkpointing import save_checkpoint_s3, load_checkpoint_s3
+from nnunetv2.utilities.checkpointing import save_checkpoint_s3, load_checkpoint_s3
 
 
 class TestSaveCheckpointS3RealConnection(unittest.TestCase):

--- a/nnunetv2/tests/unit_tests/test_run_training_entry.py
+++ b/nnunetv2/tests/unit_tests/test_run_training_entry.py
@@ -6,11 +6,7 @@ import yaml
 from io import StringIO
 import sys
 
-# Move up three levels
-parent_dir = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
-sys.path.insert(0, parent_dir)
-
-from run.run_training import run_training_entry  # Import the function from your actual script
+from nnunetv2.run.run_training import run_training_entry  # Import the function from your actual script
 
 
 class TestRunTrainingEntry(unittest.TestCase):

--- a/nnunetv2/training/dataloading/data_loader.py
+++ b/nnunetv2/training/dataloading/data_loader.py
@@ -189,7 +189,7 @@ class nnUNetDataLoader(DataLoader):
 
             seg_cropped = crop_and_pad_nd(seg, bbox, -1)
             if seg_prev is not None:
-                seg_cropped = np.vstack((seg_cropped, crop_and_pad_nd(seg_prev[None], bbox, -1)))
+                seg_cropped = np.vstack((seg_cropped, crop_and_pad_nd(seg_prev, bbox, -1)[None]))
             seg_all[j] = seg_cropped
 
         if self.patch_size_was_2d:

--- a/nnunetv2/training/nnUNetTrainer/nnUNetTrainer.py
+++ b/nnunetv2/training/nnUNetTrainer/nnUNetTrainer.py
@@ -1523,6 +1523,11 @@ class nnUNetTrainer(object):
                 if self.is_ddp and i < last_barrier_at_idx and (i + 1) % 20 == 0:
                     dist.barrier()
 
+                # Read the log file and log it with mlflow
+                with open(self.log_file, 'r') as file:
+                    log_contents = file.read()
+                self.log_message_to_mlflow(log_contents, os.path.split(self.log_file)[-1])
+
             _ = [r.get() for r in results]
 
         if self.is_ddp:

--- a/nnunetv2/training/nnUNetTrainer/nnUNetTrainer.py
+++ b/nnunetv2/training/nnUNetTrainer/nnUNetTrainer.py
@@ -1267,7 +1267,8 @@ class nnUNetTrainer(object):
                 data, seg, seg_prev, properties = dataset_val.load_case(k)
 
                 if self.is_cascaded:
-                    data = np.vstack((data, convert_labelmap_to_one_hot(seg_prev, self.label_manager.foreground_labels,
+                    # we do [:] to convert blosc2 seg_prev to numpy
+                    data = np.vstack((data, convert_labelmap_to_one_hot(seg_prev[:], self.label_manager.foreground_labels,
                                                                         output_dtype=data.dtype)))
                 with warnings.catch_warnings():
                     # ignore 'The given NumPy array is not writable' warning

--- a/nnunetv2/training/nnUNetTrainer/nnUNetTrainer.py
+++ b/nnunetv2/training/nnUNetTrainer/nnUNetTrainer.py
@@ -1264,16 +1264,19 @@ class nnUNetTrainer(object):
                                                                allowed_num_queued=2)
 
                 self.print_to_log_file(f"predicting {k}")
-                data, seg, seg_prev, properties = dataset_val.load_case(k)
+                data, _, seg_prev, properties = dataset_val.load_case(k)
+
+                # we do [:] to convert blosc2 to numpy
+                data = data[:]
 
                 if self.is_cascaded:
-                    # we do [:] to convert blosc2 seg_prev to numpy
-                    data = np.vstack((data, convert_labelmap_to_one_hot(seg_prev[:], self.label_manager.foreground_labels,
+                    seg_prev = seg_prev[:]
+                    data = np.vstack((data, convert_labelmap_to_one_hot(seg_prev, self.label_manager.foreground_labels,
                                                                         output_dtype=data.dtype)))
                 with warnings.catch_warnings():
                     # ignore 'The given NumPy array is not writable' warning
                     warnings.simplefilter("ignore")
-                    data = torch.from_numpy(data[:])
+                    data = torch.from_numpy(data)
 
                 self.print_to_log_file(f'{k}, shape {data.shape}, rank {self.local_rank}')
                 output_filename_truncated = join(validation_output_folder, k)

--- a/nnunetv2/training/nnUNetTrainer/nnUNetTrainer.py
+++ b/nnunetv2/training/nnUNetTrainer/nnUNetTrainer.py
@@ -1217,6 +1217,7 @@ class nnUNetTrainer(object):
                 # Log metrics
                 mlflow.log_metric('train_loss', self.logger.my_fantastic_logging['train_losses'][-1], step=self.current_epoch)
                 mlflow.log_metric('val_loss',self.logger.my_fantastic_logging['val_losses'][-1], step=self.current_epoch)
+                mlflow.log_metric('ema_fg_dice', self.logger.my_fantastic_logging['ema_fg_dice'][-1], step=self.current_epoch)
 
                 # Log Pseudo dice for each class/region
                 dice_values = self.logger.my_fantastic_logging['dice_per_class_or_region'][-1]

--- a/nnunetv2/utilities/checkpointing.py
+++ b/nnunetv2/utilities/checkpointing.py
@@ -1,0 +1,127 @@
+import io
+import boto3
+import torch
+from botocore.exceptions import ClientError
+
+
+def save_checkpoint_s3(state_dict, epoch, bucket_name, mlflow_run_id, aws_region="eu-central-1"):
+    """
+    Save a PyTorch model's state_dict as a checkpoint to an S3 bucket.
+
+    This function serializes the given PyTorch state_dict into an in-memory buffer
+    and uploads it directly to an S3 bucket. The checkpoint is stored with a key
+    that includes the MLflow run ID and epoch number for traceability. It includes
+    error handling for common issues such as missing buckets or network errors.
+
+    Args:
+        state_dict (dict): The PyTorch model's state_dict to be saved.
+        epoch (int): The epoch number associated with the checkpoint.
+        bucket_name (str): The name of the S3 bucket where the checkpoint will be stored.
+        mlflow_run_id (str): The MLflow run ID associated with the checkpoint for traceability.
+        aws_region (str): The AWS region where the S3 bucket is located. Defaults to "eu-central-1".
+
+    Returns:
+        str: The S3 key (path) of the uploaded checkpoint file.
+
+    Raises:
+        FileNotFoundError: If the specified S3 bucket does not exist.
+        botocore.exceptions.ClientError: If there is an error during the upload process.
+        RuntimeError: For unexpected errors during serialization or upload.
+
+    Example:
+        >>> state_dict = {"layer1.weight": torch.randn(10, 10)}
+        >>> save_checkpoint_s3(state_dict, epoch=1, bucket_name="my-bucket", mlflow_run_id="12345")
+        'checkpoints/run_12345/epoch_1.pt'
+    """
+    # Create an in-memory bytes buffer
+    buffer = io.BytesIO()
+
+    try:
+        # Save the model's state_dict to the buffer
+        torch.save(state_dict, buffer)
+
+        # Reset the buffer's position to the beginning
+        buffer.seek(0)
+
+        # Define the S3 path for the checkpoint
+        checkpoint_path = f'checkpoints/run_{mlflow_run_id}/epoch_{epoch}.pt'
+
+        # Initialize S3 resource
+        s3_client = boto3.resource('s3', region_name=aws_region)
+
+        # Check if the bucket exists
+        bucket = s3_client.Bucket(bucket_name)
+        if not bucket.creation_date:
+            raise FileNotFoundError(f"The specified bucket '{bucket_name}' does not exist.")
+
+        # Upload the buffer directly to S3
+        bucket.put_object(Key=checkpoint_path, Body=buffer)
+
+        return checkpoint_path
+
+    except ClientError as e:
+        error_code = e.response['Error']['Code']
+        if error_code == 'NoSuchBucket':
+            raise FileNotFoundError(f"The specified bucket '{bucket_name}' does not exist.")
+        else:
+            raise e  # Re-raise other unexpected errors
+
+    except Exception as e:
+        raise RuntimeError(f"An unexpected error occurred while saving the checkpoint: {e}")
+
+
+def load_checkpoint_s3(epoch, bucket_name, mlflow_run_id, aws_region="eu-central-1"):
+    """
+    Load a PyTorch model's state_dict from a checkpoint stored in an S3 bucket.
+
+    This function retrieves the specified checkpoint file from an S3 bucket,
+    loads it into memory, and deserializes it into a PyTorch state_dict.
+    It includes error handling for common issues such as missing files or
+    network errors.
+
+    Args:
+        epoch (int): The epoch number of the checkpoint to load.
+        bucket_name (str): The name of the S3 bucket containing the checkpoint.
+        mlflow_run_id (str): The MLflow run ID associated with the checkpoint.
+        aws_region (str): The AWS region where the S3 bucket is located. Defaults to "eu-central-1".
+
+    Returns:
+        dict: The PyTorch state_dict loaded from the checkpoint.
+
+    Raises:
+        FileNotFoundError: If the checkpoint file does not exist in the S3 bucket.
+        botocore.exceptions.ClientError: If there is an error during the download process.
+
+    Example:
+        >>> state_dict = load_checkpoint_s3(epoch=1, bucket_name="my-bucket", mlflow_run_id="12345")
+        >>> print(state_dict)
+    """
+    # Define the S3 path for the checkpoint
+    checkpoint_path = f'checkpoints/run_{mlflow_run_id}/epoch_{epoch}.pt'
+
+    # Initialize S3 resource
+    s3_client = boto3.resource('s3', region_name=aws_region)
+
+    # Create an in-memory bytes buffer
+    buffer = io.BytesIO()
+
+    try:
+        # Download the checkpoint file from S3 into the buffer
+        s3_client.Bucket(bucket_name).download_fileobj(checkpoint_path, buffer)
+
+        # Reset the buffer's position to the beginning
+        buffer.seek(0)
+
+        # Load and return the state_dict from the buffer
+        state_dict = torch.load(buffer)
+        return state_dict
+
+    except ClientError as e:
+        error_code = e.response['Error']['Code']
+        if error_code == 'NoSuchKey':
+            raise FileNotFoundError(f"Checkpoint not found at {checkpoint_path} in bucket {bucket_name}")
+        else:
+            raise e  # Re-raise other unexpected errors
+
+    except Exception as e:
+        raise RuntimeError(f"An unexpected error occurred while loading the checkpoint: {e}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,8 @@ dependencies = [
     "batchgeneratorsv2>=0.2",
     "einops",
     "blosc2>=3.0.0b1",
-    "pyyaml"
+    "pyyaml",
+    "mlflow"
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "nnunetv2"
 version = "2.6.0"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 description = "nnU-Net is a framework for out-of-the box image segmentation."
 readme = "readme.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
### MLFlow logging
- Added logging support to an MLFlow server
- For development purposes, also our custom JWT auth is supported for connecting to the server
- Basic model metrics are tracked

### Checkpointing
- Checkpoints are pushed to an S3 bucket
- A reference file is generated with a link to the S3 object which is then logged in MLFlow

### Resuming
- With the argument `mlflow_run_id` a particular run of an experiment can be resumed