### PR TITLE
Fixed a bug in preprocessing in crop_to_nonero,  #2796 

### DIFF
--- a/nnunetv2/preprocessing/preprocessors/default_preprocessor.py
+++ b/nnunetv2/preprocessing/preprocessors/default_preprocessor.py
@@ -62,7 +62,9 @@ class DefaultPreprocessor(object):
         shape_before_cropping = data.shape[1:]
         properties['shape_before_cropping'] = shape_before_cropping
         # this command will generate a segmentation. This is important because of the nonzero mask which we may need
-        data, seg, bbox = crop_to_nonzero(data, seg)
+        #data, seg, bbox = crop_to_nonzero(data, seg)
+        bbox = [[0, x.shape[0]] for x in data.shape[0]]
+        
         properties['bbox_used_for_cropping'] = bbox
         # print(data.shape, seg.shape)
         properties['shape_after_cropping_and_before_resampling'] = data.shape[1:]


### PR DESCRIPTION
Hi! 
#2796 

I’ve identified the root cause of the issue. In `preprocessing.preprocessors.default_preprocessor`, the function `crop_to_nonzero` is called to generate a `nonzero_mask` of the image and crop to the region of interest—but that region is defined as every non-zero pixel in the image. Clearly, that’s not correct: any voxel inside the patient can be non-zero, and manufacturer-specific differences in CT scanner background intensity mean the background is almost never exactly zero.

I see several possible solutions:

1. **Swap the preprocessing steps**: run `normalize` first, then `crop_to_nonzero`. However, this has drawbacks: if users have already cropped tightly around an organ or body region, the mask may over-crop and break training. Moreover, the CT normalization used doesn’t zero out voxels outside the body, which could lead to label errors (for example, mask labels becoming –1).

2. **Remove this heuristic entirely** and let users define the ROI before preprocessing. This would increase training time, but I believe avoiding hard-to-detect errors is worth it. **I suggest this option.**

3. **Add a toggle parameter** to enable or disable cropping. But this approach will always perform worse than other options and require extra tuning, since background intensities vary so widely. A better idea is to leverage your body-localization model [[Foreground-and-Anonymization-Area-Segmentation](https://github.com/MIC-DKFZ/Foreground-and-Anonymization-Area-Segmentation)](https://github.com/MIC-DKFZ/Foreground-and-Anonymization-Area-Segmentation). The downsides are needing to download additional weights and perform an extra inference step, plus a small chance of failure on unusual anatomies. In my opinion, though, it’s far more robust than any simple algorithmic ROI heuristic.

I spent considerable time developing heuristics to separate patient body from background, but they invariably fail when applied to diverse data from different hospitals and scanners (on the order of 1,000–2,000 varied samples). In my experience, there’s no reliable algorithmic solution for this - it simply didn’t work for me.

I understand that at the moment this doesn’t cause major training errors—since the training pipeline applies an augmentation that replaces label values of –1 with 0—but it could potentially lead to errors if mask values, rather than background, get replaced.

![Example of work _crop_to_nonzero_](https://github.com/user-attachments/assets/20e6e709-763b-4d5c-b740-6fd3e24940af)
