### PR TITLE
(very) minor fix in ZScore Norm

### DIFF
--- a/nnunetv2/preprocessing/normalization/default_normalization_schemes.py
+++ b/nnunetv2/preprocessing/normalization/default_normalization_schemes.py
@@ -33,7 +33,7 @@ class ZScoreNormalization(ImageNormalization):
         default.
         """
         image = image.astype(self.target_dtype, copy=False)
-        if self.use_mask_for_norm is not None and self.use_mask_for_norm:
+        if seg is not None and self.use_mask_for_norm:
             # negative values in the segmentation encode the 'outside' region (think zero values around the brain as
             # in BraTS). We want to run the normalization only in the brain region, so we need to mask the image.
             # The default nnU-net sets use_mask_for_norm to True if cropping to the nonzero region substantially


### PR DESCRIPTION
Hi! I believe I have identified a very minor bug when running the ZScore normalization Scheme. I think it should check that seg is supplied instead of double checking on self.use_mask_for_norm.