### PR TITLE
fix copying dataset.json to `output_folder` in `ensemble_folders` function

### DIFF
--- a/nnunetv2/ensembling/ensemble.py
+++ b/nnunetv2/ensembling/ensemble.py
@@ -3,6 +3,8 @@ import multiprocessing
 import shutil
 from copy import deepcopy
 from typing import List, Union, Tuple
+import os
+import json
 
 import numpy as np
 from batchgenerators.utilities.file_and_folder_operations import load_json, join, subfiles, \
@@ -93,7 +95,8 @@ def ensemble_folders(list_of_input_folders: List[str],
     label_manager = plans_manager.get_label_manager(dataset_json)
 
     maybe_mkdir_p(output_folder)
-    shutil.copy(join(list_of_input_folders[0], 'dataset.json'), output_folder)
+    with open(os.path.join(output_folder, 'dataset.json'), 'w') as f:
+        json.dump(dataset_json, f, indent=4)
 
     with multiprocessing.get_context("spawn").Pool(num_processes) as pool:
         num_preds = len(s)


### PR DESCRIPTION
This fix changes how the dataset.json file is written to the output folder.

The old implementation tries to copy the file at the path `join(list_of_input_folders[0], 'dataset.json'`. When `dataset_json_file_or_dict` is specified, the file at this path is probably not intended to be used by `ensemble_folders` or may not even exist. The new implementation dumps the `dataset_json` object instead to ensure `ensemble_folders` writes the correct dataset.json data to the output folder whether `dataset_json_file_or_dict` is None, a file path, or a dictionary.