### PR TITLE
Fixing a bug in predict_from_files_sequential for 3d_cascaded_fullres models

### DIFF
--- a/nnunetv2/inference/predict_from_raw_data.py
+++ b/nnunetv2/inference/predict_from_raw_data.py
@@ -748,6 +748,8 @@ class nnUNetPredictor(object):
                 self.dataset_json
             )
             if folder_with_segs_from_prev_stage is not None:
+                seg_onehot = convert_labelmap_to_one_hot(seg[0], label_manager.foreground_labels, data.dtype)
+                data = np.vstack((data, seg_onehot))
 
             print(f'perform_everything_on_device: {self.perform_everything_on_device}')
 

--- a/nnunetv2/inference/predict_from_raw_data.py
+++ b/nnunetv2/inference/predict_from_raw_data.py
@@ -31,7 +31,8 @@ from nnunetv2.utilities.file_path_utilities import get_output_folder, check_work
 from nnunetv2.utilities.find_class_by_name import recursive_find_python_class
 from nnunetv2.utilities.helpers import empty_cache, dummy_context
 from nnunetv2.utilities.json_export import recursive_fix_for_json_export
-from nnunetv2.utilities.label_handling.label_handling import determine_num_input_channels
+from nnunetv2.utilities.label_handling.label_handling import determine_num_input_channels, \
+    convert_labelmap_to_one_hot
 from nnunetv2.utilities.plans_handling.plans_handler import PlansManager, ConfigurationManager
 from nnunetv2.utilities.utils import create_lists_from_splitted_dataset_folder
 
@@ -746,6 +747,7 @@ class nnUNetPredictor(object):
                 self.configuration_manager,
                 self.dataset_json
             )
+            if folder_with_segs_from_prev_stage is not None:
 
             print(f'perform_everything_on_device: {self.perform_everything_on_device}')
 


### PR DESCRIPTION
This is to fix a bug in the predict_from_files_sequential() when predicting 3d cascaded models, where stacking the input image with the labels from a previous stage is missing. To resolve this issue, the labels from the prior stage were converted to one-hot and stacked with the input images and fed to the cascaded model. 