### PR TITLE
Remove forced HTTP 1.0 for model download

### DIFF
--- a/nnunet/inference/pretrained_models/download_pretrained_model.py
+++ b/nnunet/inference/pretrained_models/download_pretrained_model.py
@@ -279,9 +279,9 @@ def download_and_install_from_url(url):
                                                     "set (RESULTS_FOLDER missing as environment variable, see " \
                                                     "Installation instructions)"
     print('Downloading pretrained model from url:', url)
-    import http.client
-    http.client.HTTPConnection._http_vsn = 10
-    http.client.HTTPConnection._http_vsn_str = 'HTTP/1.0'
+    # import http.client
+    # http.client.HTTPConnection._http_vsn = 10
+    # http.client.HTTPConnection._http_vsn_str = 'HTTP/1.0'
 
     import os
     home = os.path.expanduser('~')


### PR DESCRIPTION
I have commented out the code that forces the archaic HTTP 1.0 enforcement. 
Since I am not sure as to why this was done, I have only commented it out. 

The PR closes #2876 