### PR TITLE
Fix Windows CI

### DIFF
--- a/.github/workflows/run_tests_nnunet.yml
+++ b/.github/workflows/run_tests_nnunet.yml
@@ -8,8 +8,7 @@ jobs:
   run-tests:
     strategy:
       matrix:
-        # os: [ubuntu-latest, windows-latest, macos-latest]  # fails on windows until https://github.com/MIC-DKFZ/nnUNet/issues/2396 is resolved
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ["3.10"]
     runs-on: ${{ matrix.os }}
 
@@ -34,7 +33,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install pytest Cython
-        pip install torch==2.4.0 -f https://download.pytorch.org/whl/cpu
+        pip install torch==2.4.1 -f https://download.pytorch.org/whl/cpu
         pip install .
 
     - name: Install dependencies on Windows / MacOS
@@ -42,7 +41,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install pytest Cython
-        pip install torch==2.4.0
+        pip install torch==2.4.1
         pip install .
 
     - name: Run test script

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+.venv/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/nnunetv2/inference/sliding_window_prediction.py
+++ b/nnunetv2/inference/sliding_window_prediction.py
@@ -16,10 +16,10 @@ def compute_gaussian(tile_size: Union[Tuple[int, ...], List[int]], sigma_scale: 
     sigmas = [i * sigma_scale for i in tile_size]
     tmp[tuple(center_coords)] = 1
     gaussian_importance_map = gaussian_filter(tmp, sigmas, 0, mode='constant', cval=0)
+    gaussian_importance_map /= (np.max(gaussian_importance_map) / value_scaling_factor)
 
     gaussian_importance_map = torch.from_numpy(gaussian_importance_map)
 
-    gaussian_importance_map /= (torch.max(gaussian_importance_map) / value_scaling_factor)
     gaussian_importance_map = gaussian_importance_map.to(device=device, dtype=dtype)
     # gaussian_importance_map cannot be 0, otherwise we may end up with nans!
     mask = gaussian_importance_map == 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,9 @@ dev = [
     "pre-commit"
 ]
 
+[tool.setuptools.packages.find]
+include = ["nnunetv2*"]
+
 [build-system]
 requires = ["setuptools>=67.8.0"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Partially fixes issue #2396 

fix windows ci
- use torch==2.4.1 (see https://github.com/MIC-DKFZ/nnUNet/issues/2396#issuecomment-3162932241_
- activate windows action

normalize gaussian using numpy
- as noted [here](https://github.com/MIC-DKFZ/nnUNet/issues/2396#issuecomment-3163312603), normalization using torch produces 'Inf' for the test case with torch==2.4.0.
- doing the operation on the numpy array instead should not have any negative side-effects

specify folder 'nnunetv2' in pyproject.toml
- doesn't hurt. I noticed when I had temporary folders (e.g., 'venv/'), setuptools was not able to install the package properly
- add `.venv/` to the gitignore file. This is a common name for a virtual environment

note: this PR does not 'fix' the issue with 2.4.0. I tried accumulating the `predicted_logits` in predict_from_raw_data.py using float32, which also helped. But in the end I still got a dice of 0.008
