### PR TITLE
Fix for "One or more background workers are no longer alive. Exiting" errors

### DIFF
--- a/nnunetv2/training/dataloading/data_loader.py
+++ b/nnunetv2/training/dataloading/data_loader.py
@@ -217,6 +217,7 @@ class nnUNetDataLoader(DataLoader):
                         seg_all = torch.stack(segs)
                     del segs, images
                     global_mutex.release()
+                
             return {'data': data_all, 'target': seg_all, 'keys': selected_keys}
 
         return {'data': data_all, 'target': seg_all, 'keys': selected_keys}


### PR DESCRIPTION
Hello,

We encountered the "One or more background workers are no longer alive. Exiting" error as described in:

https://github.com/MIC-DKFZ/nnUNet/issues/2863
https://github.com/MIC-DKFZ/nnUNet/issues/2825
https://github.com/MIC-DKFZ/nnUNet/issues/2777
https://github.com/MIC-DKFZ/nnUNet/issues/2769
https://github.com/MIC-DKFZ/nnUNet/issues/2766
https://github.com/MIC-DKFZ/nnUNet/issues/2749

when running nnUNet on an HPC cluster. A colleague and I looked into this issue and came across this link:
https://github.com/joblib/threadpoolctl/issues/176

which says that using `with threadpool_limits` is not thread safe and to use a global mutex instead. `with threadpool_limits` is used in both nnUNet and batchgenerators libraries. By using a global mutex instead of with threadpool limits as done in this pull request, we no longer encounter this issue. We verified that nnUNet output is similar (they can't be identical with the non-determinative multi-threaded launcher). 

We encountered this error with both nnUNet and the batchgenerators library so a similar pull request will be done for batchgenerators.
