### PR TITLE
add MkDocs configuration and build workflow for documentation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,26 @@
+name: Build Docs
+
+on:
+  push:
+    branches: ["master"]
+    paths:
+      - 'documentation/**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+    - name: Install MkDocs
+      run: pip install mkdocs
+    - name: Build docs
+      run: mkdocs build
+    - uses: stefanzweifel/git-auto-commit-action@v5
+      with:
+        commit_message: Update built docs
+        file_pattern: site/

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,36 @@
+site_name: nnU-Net Documentation
+site_dir: site
+docs_dir: documentation
+theme: readthedocs
+
+nav:
+  - Home: index.md
+  - Getting Started:
+    - Installation: installation_instructions.md
+    - Setting up Paths: setting_up_paths.md
+    - How to Use nnU-Net: how_to_use_nnunet.md
+  - Data Preparation:
+    - Dataset Format: dataset_format.md
+    - Dataset Format Inference: dataset_format_inference.md
+    - Converting MSD Dataset: convert_msd_dataset.md
+  - Inference:
+    - Running Inference with Pretrained Models: run_inference_with_pretrained_models.md
+  - Advanced Topics:
+    - Pretraining and Finetuning: pretraining_and_finetuning.md
+    - Extending nnU-Net: extending_nnunet.md
+    - Explanation of Plans Files: explanation_plans_files.md
+    - Explanation of Normalization: explanation_normalization.md
+    - Region-based Training: region_based_training.md
+    - ResEnc Presets: resenc_presets.md
+    - Ignore Label: ignore_label.md
+    - Manual Data Splits: manual_data_splits.md
+  - Benchmarking: benchmarking.md
+  - Changelog: changelog.md
+  - Migration from V1: tldr_migration_guide_from_v1.md
+  - Competitions:
+    - AortaSeg24: competitions/AortaSeg24.md
+    - AutoPETII: competitions/AutoPETII.md
+    - FLARE24:
+      - Task 1: competitions/FLARE24/Task_1/
+      - Task 2: competitions/FLARE24/Task_2/
+    - Toothfairy2: competitions/Toothfairy2/


### PR DESCRIPTION
## Motivation
This PR introduces MkDocs for building and hosting the project's documentation. Previously, documentation was stored as plain Markdown files in the `documentation/` directory, which limited discoverability and navigation for users. By compiling these into a structured HTML site using MkDocs, we enhance user experience with features like search, themes, and organized sections (e.g., Getting Started, Advanced Topics). This makes the docs more accessible and professional, aligning with modern open-source standards.

## Impact
- **Improved User Experience**: Compiled docs provide better navigation and readability compared to raw MD files, potentially increasing adoption and contributions.
- **Maintenance**: Centralized configuration in `mkdocs.yml` simplifies updates and ensures consistency.
- **No Breaking Changes**: Existing MD files remain intact; this only adds build tooling.
- **Performance**: Minimal overhead, as MkDocs generates static sites efficiently.

## Simple Guide to Enable Deployment with GitHub Pages
1. In your repository settings, go to **Pages** under the **Code and automation** section.
2. Set the source to **GitHub Actions** (this assumes the workflow pushes to a `gh-pages` branch or deploys directly).
3. Ensure the MkDocs workflow (e.g., `.github/workflows/docs.yml`) builds and deploys the `site/` directory. If using the `stefanzweifel/git-auto-commit-action`, it should handle pushing to the repo.
4. After merging, visit `https://<username>.github.io/<repo-name>/` to view the live docs. Update the workflow if needed to trigger on pushes to `main`.
