### PR TITLE
fix: remove unused imagecodecs dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,6 @@ dependencies = [
     "nibabel",
     "matplotlib",
     "seaborn",
-    "imagecodecs",
     "yacs",
     "batchgeneratorsv2>=0.3.0",
     "einops",


### PR DESCRIPTION
Fixes #2899

The `imagecodecs` package was listed as a dependency in `pyproject.toml` 
but is not imported or used anywhere in the nnunetv2 codebase.

This caused installation failures for users when wheel files became 
unavailable on PyPI.

This PR removes the unused dependency to prevent future breakage.

Verified by:
- Searched entire codebase for any `imagecodecs` references → zero results
- Successfully installed and ran nnUNet without `imagecodecs`