### PR TITLE
fix: reuse existing manager instance in preprocesing_iterator_fromfil…

### DIFF
--- a/nnunetv2/inference/data_iterators.py
+++ b/nnunetv2/inference/data_iterators.py
@@ -77,7 +77,7 @@ def preprocessing_iterator_fromfiles(list_of_lists: List[List[str]],
     abort_event = manager.Event()
     for i in range(num_processes):
         event = manager.Event()
-        queue = Manager().Queue(maxsize=1)
+        queue = manager().Queue(maxsize=1)
         pr = context.Process(target=preprocess_fromfiles_save_to_queue,
                      args=(
                          list_of_lists[i::num_processes],


### PR DESCRIPTION
Fix: reuse existing manager instance in preprocessing_iterator_fromfiles Manager().Queue(maxsize=1) inside the loop spawns a new manager process for each queue. Since manager is already created on line 69, this is an accidental extra instantiation.