### PR TITLE
fix: correct inverted tqdm disable flag and add descriptive labels

### DIFF
--- a/nnunetv2/experiment_planning/dataset_fingerprint/fingerprint_extractor.py
+++ b/nnunetv2/experiment_planning/dataset_fingerprint/fingerprint_extractor.py
@@ -137,7 +137,7 @@ class DatasetFingerprintExtractor(object):
                 # p is pretty nifti. If we kill workers they just respawn but don't do any work.
                 # So we need to store the original pool of workers.
                 workers = [j for j in p._pool]
-                with tqdm(desc=None, total=len(self.dataset), disable=self.verbose) as pbar:
+                with tqdm(desc="Extracting dataset fingerprint", total=len(self.dataset), disable=not self.verbose) as pbar:
                     while len(remaining) > 0:
                         all_alive = all([j.is_alive() for j in workers])
                         if not all_alive:

--- a/nnunetv2/preprocessing/preprocessors/default_preprocessor.py
+++ b/nnunetv2/preprocessing/preprocessors/default_preprocessor.py
@@ -396,7 +396,7 @@ class DefaultPreprocessor(object):
                                            plans_manager, configuration_manager,
                                            dataset_json),)))
 
-            with tqdm(desc=None, total=len(dataset), disable=self.verbose) as pbar:
+            with tqdm(desc="Preprocessing cases", total=len(dataset), disable=not self.verbose) as pbar:
                 while len(remaining) > 0:
                     all_alive = all([j.is_alive() for j in workers])
                     if not all_alive:


### PR DESCRIPTION
Fixes #2729 (partial — isolating the inverted tqdm flag fix as requested by @FabianIsensee)

## Problem
In both `default_preprocessor.py` and `fingerprint_extractor.py`, the tqdm 
`disable` flag was inverted:
```python
# BEFORE — progress bar hidden when --verbose is passed
with tqdm(desc=None, total=len(dataset), disable=self.verbose) as pbar:
```

This meant:
- Passing `--verbose` → progress bar **hidden** 
- Not passing `--verbose` → progress bar **shown** 

Completely opposite of what a user would expect.

## Fix
Flipped the flag and added meaningful descriptions:
```python
# AFTER — progress bar shown when --verbose is passed
with tqdm(desc="Preprocessing cases", total=len(dataset), disable=not self.verbose) as pbar:
```

## Changes
- `default_preprocessor.py` — `disable=self.verbose` → `disable=not self.verbose`, `desc=None` → `desc="Preprocessing cases"`
- `fingerprint_extractor.py` — `disable=self.verbose` → `disable=not self.verbose`, `desc=None` → `desc="Extracting dataset fingerprint"`

## Verification
Tested with `--verbose` flag on a Heart CT dataset:

Before: No progress bar shown during fingerprint extraction or preprocessing
After: 
- `Extracting dataset fingerprint: 100%|████████| 3/3`  
- `Preprocessing cases: 0%|          | 0/3` (visible before OMP crash)

Note: The OMP crash is the separate Windows issue being discussed in the original PR.