### PR TITLE
fix: add actionable fix instructions to affine/origin/direction mismatch warnings

### DIFF
--- a/nnunetv2/experiment_planning/verify_dataset_integrity.py
+++ b/nnunetv2/experiment_planning/verify_dataset_integrity.py
@@ -88,14 +88,12 @@ def check_cases(image_files: List[str], label_file: str, expected_num_channels: 
         affine_image = properties_image['nibabel_stuff']['original_affine']
         affine_seg = properties_seg['nibabel_stuff']['original_affine']
         if not np.allclose(affine_image, affine_seg):
-            print('WARNING: Affine is not the same for image and seg! \nAffine image: %s \nAffine seg: %s\n'
+            print('Warning: Affine mismatch between segmentation and corresponding images. '
+                '\nAffine image: %s \nAffine seg: %s\n'
                 'Image files: %s. \nSeg file: %s.\n'
-                'How to fix: Copy the image header to the segmentation using nibabel:\n'
-                '    import nibabel as nib\n'
-                '    img = nib.load("your_image.nii.gz")\n'
-                '    seg = nib.load("your_segmentation.nii.gz")\n'
-                '    seg_fixed = nib.Nifti1Image(seg.get_fdata(), img.affine, img.header)\n'
-                '    nib.save(seg_fixed, "your_segmentation_fixed.nii.gz")\n'
+                'This is a warning only and will not cause a crash. Please verify that your '
+                'segmentation and image are correctly aligned by running: '
+                'nnUNetv2_plot_overlay_pngs\n'
                 % (affine_image, affine_seg, image_files, label_file))
 
     # sitk checks
@@ -105,26 +103,20 @@ def check_cases(image_files: List[str], label_file: str, expected_num_channels: 
         origin_image = properties_image['sitk_stuff']['origin']
         origin_seg = properties_seg['sitk_stuff']['origin']
         if not np.allclose(origin_image, origin_seg):
-            print('Warning: Origin mismatch between segmentation and corresponding images. \nOrigin images: %s. '
-                '\nOrigin seg: %s. \nImage files: %s. \nSeg file: %s\n'
-                'How to fix: Copy the image header to the segmentation using SimpleITK:\n'
-                '    import SimpleITK as sitk\n'
-                '    seg = sitk.ReadImage("your_segmentation.nii.gz")\n'
-                '    img = sitk.ReadImage("your_image.nii.gz")\n'
-                '    seg.CopyInformation(img)\n'
-                '    sitk.WriteImage(seg, "your_segmentation_fixed.nii.gz")\n'
+            print('Warning: Origin mismatch between segmentation and corresponding images. '
+                '\nOrigin images: %s. \nOrigin seg: %s. \nImage files: %s. \nSeg file: %s\n'
+                'This is a warning only and will not cause a crash. Please verify that your '
+                'segmentation and image are correctly aligned by running: '
+                'nnUNetv2_plot_overlay_pngs\n'
                 % (origin_image, origin_seg, image_files, label_file))
         direction_image = properties_image['sitk_stuff']['direction']
         direction_seg = properties_seg['sitk_stuff']['direction']
         if not np.allclose(direction_image, direction_seg):
-            print('Warning: Direction mismatch between segmentation and corresponding images. \nDirection images: %s. '
-                '\nDirection seg: %s. \nImage files: %s. \nSeg file: %s\n'
-                'How to fix: Copy the image header to the segmentation using SimpleITK:\n'
-                '    import SimpleITK as sitk\n'
-                '    seg = sitk.ReadImage("your_segmentation.nii.gz")\n'
-                '    img = sitk.ReadImage("your_image.nii.gz")\n'
-                '    seg.CopyInformation(img)\n'
-                '    sitk.WriteImage(seg, "your_segmentation_fixed.nii.gz")\n'
+            print('Warning: Direction mismatch between segmentation and corresponding images. '
+                '\nDirection images: %s. \nDirection seg: %s. \nImage files: %s. \nSeg file: %s\n'
+                'This is a warning only and will not cause a crash. Please verify that your '
+                'segmentation and image are correctly aligned by running: '
+                'nnUNetv2_plot_overlay_pngs\n'
                 % (direction_image, direction_seg, image_files, label_file))
 
     return ret


### PR DESCRIPTION
Fixes #2751

## Problem
When running `nnUNetv2_plan_and_preprocess --verify_dataset_integrity`, 
the origin, direction, and affine mismatch warning messages were vague 
and gave users no context about what the warning meant or how serious it was.

## Fix
Improved the warning messages in `verify_dataset_integrity.py` to:
- Clearly state that these are warnings only and will not cause a crash
- Remind users to verify alignment visually using `nnUNetv2_plot_overlay_pngs`
- Avoid making any assumptions about how to fix the geometry mismatch
  (as the correct fix depends entirely on how the data was prepared)

## Before
Warning: Origin mismatch between segmentation and corresponding images.
Origin images: (-100.0, 150.0, 50.0).
Origin seg: (0.0, 0.0, 0.0).
No context, no guidance ❌

## After
Warning: Origin mismatch between segmentation and corresponding images.
Origin images: (-100.0, 150.0, 50.0).
Origin seg: (0.0, 0.0, 0.0).
This is a warning only and will not cause a crash. Please verify that
your segmentation and image are correctly aligned by running:
nnUNetv2_plot_overlay_pngs
Clear, informative, no unsafe assumptions ✅

## Verification
Tested with a dummy CT dataset with intentionally mismatched affines 
warnings now clearly communicate severity and next steps without 
making any assumptions about the user's data.