### PR TITLE
Improve environment variable validation across core workflows

### DIFF
--- a/nnunetv2/experiment_planning/plan_and_preprocess_api.py
+++ b/nnunetv2/experiment_planning/plan_and_preprocess_api.py
@@ -8,7 +8,10 @@ from nnunetv2.configuration import default_num_processes
 from nnunetv2.experiment_planning.dataset_fingerprint.fingerprint_extractor import DatasetFingerprintExtractor
 from nnunetv2.experiment_planning.experiment_planners.default_experiment_planner import ExperimentPlanner
 from nnunetv2.experiment_planning.verify_dataset_integrity import verify_dataset_integrity
-from nnunetv2.paths import nnUNet_raw, nnUNet_preprocessed
+from nnunetv2.paths import (
+    require_preprocessed_dataset_path,
+    require_raw_dataset_path,
+)
 from nnunetv2.utilities.dataset_name_id_conversion import convert_id_to_dataset_name
 from nnunetv2.utilities.find_class_by_name import recursive_find_python_class
 from nnunetv2.utilities.plans_handling.plans_handler import PlansManager
@@ -26,9 +29,11 @@ def extract_fingerprint_dataset(dataset_id: int,
     """
     dataset_name = convert_id_to_dataset_name(dataset_id)
     print(dataset_name)
+    raw_dir = require_raw_dataset_path('dataset fingerprint extraction')
+    require_preprocessed_dataset_path('dataset fingerprint extraction')
 
     if check_dataset_integrity:
-        verify_dataset_integrity(join(nnUNet_raw, dataset_name), num_processes)
+        verify_dataset_integrity(join(raw_dir, dataset_name), num_processes)
 
     fpe = fingerprint_extractor_class(dataset_id, num_processes, verbose=verbose)
     if hasattr(fpe, 'show_progress_bar'):
@@ -119,8 +124,10 @@ def preprocess_dataset(dataset_id: int,
             f'{len(num_processes)}')
 
     dataset_name = convert_id_to_dataset_name(dataset_id)
+    raw_dir = require_raw_dataset_path('preprocessing')
+    preprocessed_dir = require_preprocessed_dataset_path('preprocessing')
     print(f'Preprocessing dataset {dataset_name}')
-    plans_file = join(nnUNet_preprocessed, dataset_name, plans_identifier + '.json')
+    plans_file = join(preprocessed_dir, dataset_name, plans_identifier + '.json')
     plans_manager = PlansManager(plans_file)
     for n, c in zip(num_processes, configurations):
         print(f'Configuration: {c}...')
@@ -139,13 +146,13 @@ def preprocess_dataset(dataset_id: int,
     # copy the gt to a folder in the nnUNet_preprocessed so that we can do validation even if the raw data is no
     # longer there (useful for compute cluster where only the preprocessed data is available)
     from distutils.file_util import copy_file
-    maybe_mkdir_p(join(nnUNet_preprocessed, dataset_name, 'gt_segmentations'))
-    dataset_json = load_json(join(nnUNet_raw, dataset_name, 'dataset.json'))
-    dataset = get_filenames_of_train_images_and_targets(join(nnUNet_raw, dataset_name), dataset_json)
+    maybe_mkdir_p(join(preprocessed_dir, dataset_name, 'gt_segmentations'))
+    dataset_json = load_json(join(raw_dir, dataset_name, 'dataset.json'))
+    dataset = get_filenames_of_train_images_and_targets(join(raw_dir, dataset_name), dataset_json)
     # only copy files that are newer than the ones already present
     for k in dataset:
         copy_file(dataset[k]['label'],
-                  join(nnUNet_preprocessed, dataset_name, 'gt_segmentations', k + dataset_json['file_ending']),
+                  join(preprocessed_dir, dataset_name, 'gt_segmentations', k + dataset_json['file_ending']),
                   update=True)
 
 

--- a/nnunetv2/model_sharing/model_download.py
+++ b/nnunetv2/model_sharing/model_download.py
@@ -4,14 +4,12 @@ import requests
 from batchgenerators.utilities.file_and_folder_operations import *
 from time import time
 from nnunetv2.model_sharing.model_import import install_model_from_zip_file
-from nnunetv2.paths import nnUNet_results
+from nnunetv2.paths import require_results_path
 from tqdm import tqdm
 
 
 def download_and_install_from_url(url):
-    assert nnUNet_results is not None, "Cannot install model because network_training_output_dir is not " \
-                                                    "set (RESULTS_FOLDER missing as environment variable, see " \
-                                                    "Installation instructions)"
+    require_results_path('installing pretrained models')
     print('Downloading pretrained model from url:', url)
     import http.client
     http.client.HTTPConnection._http_vsn = 10

--- a/nnunetv2/model_sharing/model_export.py
+++ b/nnunetv2/model_sharing/model_export.py
@@ -12,6 +12,7 @@ def export_pretrained_model(dataset_name_or_id: Union[int, str], output_file: st
                             save_checkpoints: Tuple[str, ...] = ('checkpoint_final.pth',),
                             export_crossval_predictions: bool = False) -> None:
     dataset_name = maybe_convert_to_dataset_name(dataset_name_or_id)
+    results_dir = require_results_path('exporting pretrained models')
     with(zipfile.ZipFile(output_file, 'w', zipfile.ZIP_DEFLATED)) as zipf:
         for c in configurations:
             print(f"Configuration {c}")
@@ -34,32 +35,32 @@ def export_pretrained_model(dataset_name_or_id: Union[int, str], output_file: st
                 # debug.json, does not exist yet
                 source_file = join(trainer_output_dir, fold_folder, "debug.json")
                 if isfile(source_file):
-                    zipf.write(source_file, os.path.relpath(source_file, nnUNet_results))
+                    zipf.write(source_file, os.path.relpath(source_file, results_dir))
 
                 # all requested checkpoints
                 for chk in save_checkpoints:
                     source_file = join(trainer_output_dir, fold_folder, chk)
-                    zipf.write(source_file, os.path.relpath(source_file, nnUNet_results))
+                    zipf.write(source_file, os.path.relpath(source_file, results_dir))
 
                 # progress.png
                 source_file = join(trainer_output_dir, fold_folder, "progress.png")
-                zipf.write(source_file, os.path.relpath(source_file, nnUNet_results))
+                zipf.write(source_file, os.path.relpath(source_file, results_dir))
 
                 # if it exists, network architecture.png
                 source_file = join(trainer_output_dir, fold_folder, "network_architecture.pdf")
                 if isfile(source_file):
-                    zipf.write(source_file, os.path.relpath(source_file, nnUNet_results))
+                    zipf.write(source_file, os.path.relpath(source_file, results_dir))
 
                 # validation folder with all predicted segmentations etc
                 if export_crossval_predictions:
                     source_folder = join(trainer_output_dir, fold_folder, "validation")
                     files = [i for i in subfiles(source_folder, join=False) if not i.endswith('.npz') and not i.endswith('.pkl')]
                     for f in files:
-                        zipf.write(join(source_folder, f), os.path.relpath(join(source_folder, f), nnUNet_results))
+                        zipf.write(join(source_folder, f), os.path.relpath(join(source_folder, f), results_dir))
                 # just the summary.json file from the validation
                 else:
                     source_file = join(trainer_output_dir, fold_folder, "validation", "summary.json")
-                    zipf.write(source_file, os.path.relpath(source_file, nnUNet_results))
+                    zipf.write(source_file, os.path.relpath(source_file, results_dir))
 
             source_folder = join(trainer_output_dir, f'crossval_results_folds_{folds_tuple_to_string(folds)}')
             if isdir(source_folder):
@@ -72,18 +73,18 @@ def export_pretrained_model(dataset_name_or_id: Union[int, str], output_file: st
                     ]
                 for s in source_files:
                     if isfile(s):
-                        zipf.write(s, os.path.relpath(s, nnUNet_results))
+                        zipf.write(s, os.path.relpath(s, results_dir))
             # plans
             source_file = join(trainer_output_dir, "plans.json")
-            zipf.write(source_file, os.path.relpath(source_file, nnUNet_results))
+            zipf.write(source_file, os.path.relpath(source_file, results_dir))
             # fingerprint
             source_file = join(trainer_output_dir, "dataset_fingerprint.json")
-            zipf.write(source_file, os.path.relpath(source_file, nnUNet_results))
+            zipf.write(source_file, os.path.relpath(source_file, results_dir))
             # dataset
             source_file = join(trainer_output_dir, "dataset.json")
-            zipf.write(source_file, os.path.relpath(source_file, nnUNet_results))
+            zipf.write(source_file, os.path.relpath(source_file, results_dir))
 
-        ensemble_dir = join(nnUNet_results, dataset_name, 'ensembles')
+        ensemble_dir = join(results_dir, dataset_name, 'ensembles')
 
         if not isdir(ensemble_dir):
             print("No ensemble directory found for task", dataset_name_or_id)
@@ -110,13 +111,13 @@ def export_pretrained_model(dataset_name_or_id: Union[int, str], output_file: st
                         ['summary.json', 'postprocessing.pkl', 'postprocessing.json'] if isfile(join(source_folder, i))
                     ]
                 for s in source_files:
-                    zipf.write(s, os.path.relpath(s, nnUNet_results))
-        inference_information_file = join(nnUNet_results, dataset_name, 'inference_information.json')
+                    zipf.write(s, os.path.relpath(s, results_dir))
+        inference_information_file = join(results_dir, dataset_name, 'inference_information.json')
         if isfile(inference_information_file):
-            zipf.write(inference_information_file, os.path.relpath(inference_information_file, nnUNet_results))
-        inference_information_txt_file = join(nnUNet_results, dataset_name, 'inference_information.txt')
+            zipf.write(inference_information_file, os.path.relpath(inference_information_file, results_dir))
+        inference_information_txt_file = join(results_dir, dataset_name, 'inference_information.txt')
         if isfile(inference_information_txt_file):
-            zipf.write(inference_information_txt_file, os.path.relpath(inference_information_txt_file, nnUNet_results))
+            zipf.write(inference_information_txt_file, os.path.relpath(inference_information_txt_file, results_dir))
     print('Done')
 
 

--- a/nnunetv2/model_sharing/model_import.py
+++ b/nnunetv2/model_sharing/model_import.py
@@ -1,8 +1,9 @@
 import zipfile
 
-from nnunetv2.paths import nnUNet_results
+from nnunetv2.paths import require_results_path
 
 
 def install_model_from_zip_file(zip_file: str):
+    results_dir = require_results_path('installing pretrained models')
     with zipfile.ZipFile(zip_file, 'r') as zip_ref:
-        zip_ref.extractall(nnUNet_results)
+        zip_ref.extractall(results_dir)

--- a/nnunetv2/paths.py
+++ b/nnunetv2/paths.py
@@ -13,6 +13,7 @@
 #    limitations under the License.
 
 import os
+import warnings
 
 """
 PLEASE READ documentation/setting_up_paths.md FOR INFORMATION TO HOW TO SET THIS UP
@@ -22,18 +23,49 @@ nnUNet_raw = os.environ.get('nnUNet_raw')
 nnUNet_preprocessed = os.environ.get('nnUNet_preprocessed')
 nnUNet_results = os.environ.get('nnUNet_results')
 
-if nnUNet_raw is None:
-    print("nnUNet_raw is not defined and nnU-Net can only be used on data for which preprocessed files "
-          "are already present on your system. nnU-Net cannot be used for experiment planning and preprocessing like "
-          "this. If this is not intended, please read documentation/setting_up_paths.md for information on how to set "
-          "this up properly.")
+_SETTING_UP_PATHS_DOC = 'documentation/setting_up_paths.md'
+_DEFAULT_USAGE_BY_ENV_VAR = {
+    'nnUNet_raw': 'experiment planning and preprocessing',
+    'nnUNet_preprocessed': 'preprocessing and training',
+    'nnUNet_results': 'training and inference',
+}
 
-if nnUNet_preprocessed is None:
-    print("nnUNet_preprocessed is not defined and nnU-Net can not be used for preprocessing "
-          "or training. If this is not intended, please read documentation/setting_up_paths.md for information on how "
-          "to set this up.")
 
-if nnUNet_results is None:
-    print("nnUNet_results is not defined and nnU-Net cannot be used for training or "
-          "inference. If this is not intended behavior, please read documentation/setting_up_paths.md for information "
-          "on how to set this up.")
+def _build_missing_path_message(env_var_name: str, required_for: str = None) -> str:
+    message = f"Environment variable '{env_var_name}' is not set."
+    if required_for is not None:
+        message += f" It is required for {required_for}."
+    message += f" Please configure it according to {_SETTING_UP_PATHS_DOC}"
+    return message
+
+
+def _warn_if_missing(env_var_name: str, current_value: str) -> None:
+    if current_value is None:
+        warnings.warn(
+            _build_missing_path_message(env_var_name, _DEFAULT_USAGE_BY_ENV_VAR[env_var_name]),
+            stacklevel=1,
+        )
+
+
+def get_required_path(env_var_name: str, required_for: str = None) -> str:
+    value = os.environ.get(env_var_name)
+    if value is None:
+        raise EnvironmentError(_build_missing_path_message(env_var_name, required_for))
+    return value
+
+
+def require_raw_dataset_path(required_for: str = None) -> str:
+    return get_required_path('nnUNet_raw', required_for)
+
+
+def require_preprocessed_dataset_path(required_for: str = None) -> str:
+    return get_required_path('nnUNet_preprocessed', required_for)
+
+
+def require_results_path(required_for: str = None) -> str:
+    return get_required_path('nnUNet_results', required_for)
+
+
+_warn_if_missing('nnUNet_raw', nnUNet_raw)
+_warn_if_missing('nnUNet_preprocessed', nnUNet_preprocessed)
+_warn_if_missing('nnUNet_results', nnUNet_results)

--- a/nnunetv2/run/run_training.py
+++ b/nnunetv2/run/run_training.py
@@ -8,7 +8,7 @@ import torch.cuda
 import torch.distributed as dist
 import torch.multiprocessing as mp
 from batchgenerators.utilities.file_and_folder_operations import join, isfile, load_json
-from nnunetv2.paths import nnUNet_preprocessed
+from nnunetv2.paths import require_preprocessed_dataset_path, require_results_path
 from nnunetv2.run.load_pretrained_weights import load_pretrained_weights
 from nnunetv2.training.nnUNetTrainer.nnUNetTrainer import nnUNetTrainer
 from nnunetv2.utilities.dataset_name_id_conversion import maybe_convert_to_dataset_name
@@ -59,7 +59,8 @@ def get_trainer_from_args(dataset_name_or_id: Union[int, str],
                              f'input: {dataset_name_or_id}')
 
     # initialize nnunet trainer
-    preprocessed_dataset_folder_base = join(nnUNet_preprocessed, maybe_convert_to_dataset_name(dataset_name_or_id))
+    preprocessed_dir = require_preprocessed_dataset_path('training')
+    preprocessed_dataset_folder_base = join(preprocessed_dir, maybe_convert_to_dataset_name(dataset_name_or_id))
     plans_file = join(preprocessed_dataset_folder_base, plans_identifier + '.json')
     plans = load_json(plans_file)
     plans["continue_training"] = continue_training
@@ -148,6 +149,8 @@ def run_training(dataset_name_or_id: Union[str, int],
                  disable_checkpointing: bool = False,
                  val_with_best: bool = False,
                  device: torch.device = torch.device('cuda')):
+    require_preprocessed_dataset_path('training')
+    require_results_path('training')
     if plans_identifier == 'nnUNetPlans':
         print("\n############################\n"
               "INFO: You are using the old nnU-Net default plans. We have updated our recommendations. "

--- a/nnunetv2/utilities/file_path_utilities.py
+++ b/nnunetv2/utilities/file_path_utilities.py
@@ -4,7 +4,7 @@ import numpy as np
 from batchgenerators.utilities.file_and_folder_operations import *
 
 from nnunetv2.configuration import default_num_processes
-from nnunetv2.paths import nnUNet_results
+from nnunetv2.paths import require_results_path
 from nnunetv2.utilities.dataset_name_id_conversion import maybe_convert_to_dataset_name
 
 
@@ -19,7 +19,8 @@ def convert_identifier_to_trainer_plans_config(identifier: str):
 def get_output_folder(dataset_name_or_id: Union[str, int], trainer_name: str = 'nnUNetTrainer',
                       plans_identifier: str = 'nnUNetPlans', configuration: str = '3d_fullres',
                       fold: Union[str, int] = None) -> str:
-    tmp = join(nnUNet_results, maybe_convert_to_dataset_name(dataset_name_or_id),
+    results_dir = require_results_path('resolving model output folders')
+    tmp = join(results_dir, maybe_convert_to_dataset_name(dataset_name_or_id),
                convert_trainer_plans_config_to_identifier(trainer_name, plans_identifier, configuration))
     if fold is not None:
         tmp = join(tmp, f'fold_{fold}')


### PR DESCRIPTION
## Summary
This PR improves how nnU-Net validates required environment variables for path-based workflows.

## Problem
Missing path environment variables can currently surface later as less actionable failures. Raising immediately at import time would also break workflows that do not require all three paths.

## What this PR changes
- adds reusable helpers in `nnunetv2.paths` for validating required environment variables
- preserves import-time behavior so optional workflows are not broken by missing unrelated paths
- adds contextual validation where the paths are actually required:
  - experiment planning / preprocessing
  - training
  - model import / export / download
  - output folder resolution

## Why this approach
This keeps the change generally applicable across setups while avoiding unnecessary breakage in workflows that only depend on a subset of nnU-Net paths.

## Validation
- verified updated modules compile successfully with `python -m compileall`
- manually verified warning behavior on import when env vars are missing
- manually verified explicit errors when required paths are missing
- manually verified success behavior when paths are set
