### PR TITLE
fix: logging implementation was hidding exceptions in nnUNetTrainerBenchmark_5epochs and nnUNetTrainerBenchmark_5epochs_noDataLoading

### DIFF
--- a/nnunetv2/training/nnUNetTrainer/variants/benchmarking/nnUNetTrainerBenchmark_5epochs.py
+++ b/nnunetv2/training/nnUNetTrainer/variants/benchmarking/nnUNetTrainerBenchmark_5epochs.py
@@ -27,9 +27,10 @@ class nnUNetTrainerBenchmark_5epochs(nnUNetTrainer):
     def run_training(self):
         try:
             super().run_training()
-        except RuntimeError:
+        except RuntimeError as e:
             self.crashed_with_runtime_error = True
             self.on_train_end()
+            self.print_to_log_file(f"An Exception occurred: {e}")
 
     def on_train_end(self):
         super().on_train_end()
@@ -39,7 +40,7 @@ class nnUNetTrainerBenchmark_5epochs(nnUNetTrainer):
             cudnn_version = torch.backends.cudnn.version()
             gpu_name = torch.cuda.get_device_name()
             if self.crashed_with_runtime_error:
-                fastest_epoch = 'Not enough VRAM!'
+                fastest_epoch = 'Training has ended due to an error. Check your logs for more information.'
             else:
                 epoch_times = [i - j for i, j in zip(self.logger.my_fantastic_logging['epoch_end_timestamps'],
                                                      self.logger.my_fantastic_logging['epoch_start_timestamps'])]

--- a/nnunetv2/training/nnUNetTrainer/variants/benchmarking/nnUNetTrainerBenchmark_5epochs_noDataLoading.py
+++ b/nnunetv2/training/nnUNetTrainer/variants/benchmarking/nnUNetTrainerBenchmark_5epochs_noDataLoading.py
@@ -60,5 +60,7 @@ class nnUNetTrainerBenchmark_5epochs_noDataLoading(nnUNetTrainerBenchmark_5epoch
                 self.on_epoch_end()
 
             self.on_train_end()
-        except RuntimeError:
+        except RuntimeError as e:
             self.crashed_with_runtime_error = True
+            self.on_train_end()
+            self.print_to_log_file(f"An Exception occurred: {e}")


### PR DESCRIPTION
Hi,

The logging implementation in both edited file was hiding this error:

```
backend='inductor' raised:
RuntimeError: Triton Error [CUDA]: device kernel image is invalid

Set TORCH_LOGS="+dynamo" and TORCHDYNAMO_VERBOSE=1 for more information
You can suppress this exception and fall back to eager by setting:
    import torch._dynamo
    torch._dynamo.config.suppress_errors = True
```

It was reporting this error as :
fastest_epoch = 'Not enough VRAM!'

While I had more than enought VRAM to run my network.

I got the solution for my error here : https://github.com/pytorch/pytorch/issues/119054

Apparently something is wrong with the ptxas bundled by default with triton. 
Using my own, by defining the environment variable TRITON_PTXAS_PATH="/usr/local/cuda-11.6/bin/ptxas"  fixed my issue.

I changed the logging so that it displays the exception in the logs and now the message is accurate :
fastest_epoch = 'Training has ended due to an error. Check your logs for more information.'



