### PR TITLE
Fixed typo in saving properties associated to predicted probabilities

### DIFF
--- a/nnunetv2/ensembling/ensemble.py
+++ b/nnunetv2/ensembling/ensemble.py
@@ -44,7 +44,7 @@ def merge_files(list_of_files,
     image_reader_writer.write_seg(segmentation, output_filename_truncated + output_file_ending, properties)
     if save_probabilities:
         np.savez_compressed(output_filename_truncated + '.npz', probabilities=probabilities)
-        save_pickle(probabilities, output_filename_truncated + '.pkl')
+        save_pickle(properties, output_filename_truncated + '.pkl')
 
 
 def ensemble_folders(list_of_input_folders: List[str],


### PR DESCRIPTION
Fixes #2781 

Typo in the `merge_files` function when saving the averages probabilities with the `--save_probabilities` option in `nnUNetv2_predict` for example.

`probabilities` were save in the pickle file instead of `properties`