### PR TITLE
Improve --val_best

### DIFF
--- a/nnunetv2/training/nnUNetTrainer/fixed_val_tiles.py
+++ b/nnunetv2/training/nnUNetTrainer/fixed_val_tiles.py
@@ -1,0 +1,162 @@
+from dataclasses import dataclass
+from itertools import product
+from typing import List, Optional, Tuple
+
+import numpy as np
+import torch
+from acvl_utils.cropping_and_padding.bounding_boxes import crop_and_pad_nd
+
+from nnunetv2.inference.sliding_window_prediction import compute_steps_for_sliding_window
+
+
+@dataclass(frozen=True)
+class FixedValTile:
+    """A deterministic validation crop.
+
+    key is the dataset case identifier passed to dataset.load_case.
+    starts can have these shapes:
+    - (y_start, x_start) for native 2D patches on 2D cases.
+    - (z_start, y_start, x_start) for native 3D patches on 3D cases.
+    - (slice_idx, y_start, x_start) for 2D patches applied slice-by-slice to 3D cases.
+    """
+    key: str
+    starts: Tuple[int, ...]
+
+
+@dataclass(frozen=True)
+class FixedValTileStats:
+    num_cases: int
+    num_candidate_tiles: int
+    num_requested_tiles: int
+    num_selected_tiles: int
+    num_tiles_on_rank: int
+
+
+class FixedValTileManager:
+    def __init__(self, dataset, patch_size: Tuple[int, ...], batch_size: int, transforms,
+                 tile_step_size: float, seed: int, num_tiles: Optional[int], default_num_tiles: int,
+                 is_ddp: bool = False, rank: int = 0, world_size: int = 1):
+        self.dataset = dataset
+        self.patch_size = patch_size
+        self.batch_size = batch_size
+        self.transforms = transforms
+        self.tile_step_size = tile_step_size
+        self.seed = seed
+        self.num_tiles = num_tiles
+        self.default_num_tiles = default_num_tiles
+        self.is_ddp = is_ddp
+        self.rank = rank
+        self.world_size = world_size
+        self.tiles, self.stats = self._build_tiles()
+
+    def __len__(self):
+        return len(self.tiles)
+
+    def iter_batches(self):
+        for batch_start in range(0, len(self.tiles), self.batch_size):
+            yield self._make_batch(self.tiles[batch_start:batch_start + self.batch_size])
+
+    def _build_tiles(self) -> Tuple[List[FixedValTile], FixedValTileStats]:
+        tiles = []
+        num_cases = len(self.dataset.identifiers)
+
+        for key in self.dataset.identifiers:
+            data, _, _, _ = self.dataset.load_case(key)
+            image_size = tuple(int(i) for i in data.shape[1:])
+
+            if len(self.patch_size) < len(image_size):
+                # 2D configurations keep 3D cases as (c, z, y, x) but use 2D patches (y, x), so we
+                # enumerate in-plane sliding-window tiles for each slice independently.
+                assert len(self.patch_size) == len(image_size) - 1
+                # compute_steps_for_sliding_window requires image_size >= patch_size. For smaller validation
+                # slices we enumerate one virtual patch-sized tile and let crop_and_pad_nd add the padding later.
+                tiled_size = tuple(max(i, p) for i, p in zip(image_size[1:], self.patch_size))
+                steps = compute_steps_for_sliding_window(tiled_size, self.patch_size, self.tile_step_size)
+                for slice_idx in range(image_size[0]):
+                    for starts in product(*steps):
+                        tiles.append(FixedValTile(key, (slice_idx, *starts)))
+            else:
+                # compute_steps_for_sliding_window requires image_size >= patch_size. For smaller validation
+                # images we enumerate one virtual patch-sized tile and let crop_and_pad_nd add the padding later.
+                tiled_size = tuple(max(i, p) for i, p in zip(image_size, self.patch_size))
+                steps = compute_steps_for_sliding_window(tiled_size, self.patch_size, self.tile_step_size)
+                for starts in product(*steps):
+                    tiles.append(FixedValTile(key, tuple(starts)))
+
+        num_candidate_tiles = len(tiles)
+        requested_num_tiles = self.default_num_tiles if self.num_tiles is None else int(self.num_tiles)
+        selected_num_tiles = min(requested_num_tiles, len(tiles))
+
+        if selected_num_tiles < len(tiles):
+            rng = np.random.default_rng(self.seed)
+            selected_indices = np.sort(rng.choice(len(tiles), size=selected_num_tiles, replace=False))
+            tiles = [tiles[i] for i in selected_indices]
+
+        num_selected_tiles = len(tiles)
+        if self.is_ddp:
+            if len(tiles) < self.world_size:
+                raise RuntimeError(
+                    f"Fixed validation selected {len(tiles)} tiles for {self.world_size} DDP ranks. "
+                    f"Increase fixed_val_num_tiles or validate with fewer ranks so every rank gets at least one tile."
+                )
+            tiles = tiles[self.rank::self.world_size]
+
+        stats = FixedValTileStats(
+            num_cases=num_cases,
+            num_candidate_tiles=num_candidate_tiles,
+            num_requested_tiles=requested_num_tiles,
+            num_selected_tiles=num_selected_tiles,
+            num_tiles_on_rank=len(tiles),
+        )
+        return tiles, stats
+
+    def _crop_tile(self, data: np.ndarray, seg: np.ndarray, seg_prev: Optional[np.ndarray],
+                   starts: Tuple[int, ...]) -> Tuple[torch.Tensor, torch.Tensor]:
+        if len(starts) == len(self.patch_size) + 1:
+            # 2D-over-3D case: starts contains the selected slice index followed by the in-plane
+            # tile starts, so crop a single (y, x) slice from data shaped (c, z, y, x).
+            slice_idx = starts[0]
+            spatial_starts = starts[1:]
+            bbox = [[i, i + j] for i, j in zip(spatial_starts, self.patch_size)]
+            data_cropped = crop_and_pad_nd(data[:, slice_idx], bbox, 0)
+            seg_cropped = crop_and_pad_nd(seg[:, slice_idx], bbox, -1)
+            if seg_prev is not None:
+                seg_prev_cropped = crop_and_pad_nd(seg_prev[slice_idx], bbox, -1)
+                seg_cropped = np.concatenate((seg_cropped, seg_prev_cropped[None]), axis=0)
+        else:
+            bbox = [[i, i + j] for i, j in zip(starts, self.patch_size)]
+            data_cropped = crop_and_pad_nd(data, bbox, 0)
+            seg_cropped = crop_and_pad_nd(seg, bbox, -1)
+            if seg_prev is not None:
+                seg_prev_cropped = crop_and_pad_nd(seg_prev, bbox, -1)
+                seg_cropped = np.concatenate((seg_cropped, seg_prev_cropped[None]), axis=0)
+
+        return torch.from_numpy(data_cropped).float(), torch.from_numpy(seg_cropped).to(torch.int16)
+
+    def _make_batch(self, tiles: List[FixedValTile]) -> dict:
+        data_samples = []
+        seg_samples = []
+
+        for tile in tiles:
+            data, seg, seg_prev, _ = self.dataset.load_case(tile.key)
+            data = np.asarray(data[:])
+            seg = np.asarray(seg[:])
+            if seg_prev is not None:
+                seg_prev = np.asarray(seg_prev[:])
+
+            data_cropped, seg_cropped = self._crop_tile(data, seg, seg_prev, tile.starts)
+            transformed = self.transforms(image=data_cropped, segmentation=seg_cropped)
+            data_samples.append(transformed['image'])
+            seg_samples.append(transformed['segmentation'])
+
+        data_batch = torch.stack(data_samples)
+
+        if isinstance(seg_samples[0], list):
+            target_batch = [
+                torch.stack([sample[scale_idx] for sample in seg_samples])
+                for scale_idx in range(len(seg_samples[0]))
+            ]
+        else:
+            target_batch = torch.stack(seg_samples)
+
+        return {'data': data_batch, 'target': target_batch, 'keys': [tile.key for tile in tiles]}

--- a/nnunetv2/training/nnUNetTrainer/fixed_val_tiles.py
+++ b/nnunetv2/training/nnUNetTrainer/fixed_val_tiles.py
@@ -115,8 +115,8 @@ class FixedValTileManager:
             # tile starts, so crop a single (y, x) slice from data shaped (c, z, y, x).
             slice_idx = starts[0]
             spatial_starts = starts[1:]
-            # crop_and_pad_nd expects one [start, end] interval per spatial axis.
-            # and our target size is self.patch_size
+            # crop_and_pad_nd expects one [start, end] interval per spatial axis
+            # and our target size is self.patch_size.
             bbox = [[i, i + j] for i, j in zip(spatial_starts, self.patch_size)]
             data_cropped = crop_and_pad_nd(data[:, slice_idx], bbox, 0)
             seg_cropped = crop_and_pad_nd(seg[:, slice_idx], bbox, -1)
@@ -124,8 +124,8 @@ class FixedValTileManager:
                 seg_prev_cropped = crop_and_pad_nd(seg_prev[slice_idx], bbox, -1)
                 seg_cropped = np.concatenate((seg_cropped, seg_prev_cropped[None]), axis=0)
         else:
-            # crop_and_pad_nd expects one [start, end] interval per spatial axis.
-            # and our target size is self.patch_size
+            # crop_and_pad_nd expects one [start, end] interval per spatial axis
+            # and our target size is self.patch_size.
             bbox = [[i, i + j] for i, j in zip(starts, self.patch_size)]
             data_cropped = crop_and_pad_nd(data, bbox, 0)
             seg_cropped = crop_and_pad_nd(seg, bbox, -1)

--- a/nnunetv2/training/nnUNetTrainer/fixed_val_tiles.py
+++ b/nnunetv2/training/nnUNetTrainer/fixed_val_tiles.py
@@ -34,7 +34,7 @@ class FixedValTileStats:
 
 class FixedValTileManager:
     def __init__(self, dataset, patch_size: Tuple[int, ...], batch_size: int, transforms,
-                 tile_step_size: float, seed: int, num_tiles: Optional[int], default_num_tiles: int,
+                 tile_step_size: float, seed: int, num_tiles: int,
                  is_ddp: bool = False, rank: int = 0, world_size: int = 1):
         self.dataset = dataset
         self.patch_size = patch_size
@@ -43,7 +43,6 @@ class FixedValTileManager:
         self.tile_step_size = tile_step_size
         self.seed = seed
         self.num_tiles = num_tiles
-        self.default_num_tiles = default_num_tiles
         self.is_ddp = is_ddp
         self.rank = rank
         self.world_size = world_size
@@ -84,7 +83,7 @@ class FixedValTileManager:
                     tiles.append(FixedValTile(key, tuple(starts)))
 
         num_candidate_tiles = len(tiles)
-        requested_num_tiles = self.default_num_tiles if self.num_tiles is None else int(self.num_tiles)
+        requested_num_tiles = int(self.num_tiles)
         selected_num_tiles = min(requested_num_tiles, len(tiles))
 
         if selected_num_tiles < len(tiles):

--- a/nnunetv2/training/nnUNetTrainer/fixed_val_tiles.py
+++ b/nnunetv2/training/nnUNetTrainer/fixed_val_tiles.py
@@ -84,11 +84,10 @@ class FixedValTileManager:
 
         num_candidate_tiles = len(tiles)
         requested_num_tiles = int(self.num_tiles)
-        selected_num_tiles = min(requested_num_tiles, len(tiles))
 
-        if selected_num_tiles < len(tiles):
+        if requested_num_tiles < len(tiles):
             rng = np.random.default_rng(self.seed)
-            selected_indices = np.sort(rng.choice(len(tiles), size=selected_num_tiles, replace=False))
+            selected_indices = rng.choice(len(tiles), size=requested_num_tiles, replace=False)
             tiles = [tiles[i] for i in selected_indices]
 
         num_selected_tiles = len(tiles)
@@ -116,6 +115,8 @@ class FixedValTileManager:
             # tile starts, so crop a single (y, x) slice from data shaped (c, z, y, x).
             slice_idx = starts[0]
             spatial_starts = starts[1:]
+            # crop_and_pad_nd expects one [start, end] interval per spatial axis.
+            # and our target size is self.patch_size
             bbox = [[i, i + j] for i, j in zip(spatial_starts, self.patch_size)]
             data_cropped = crop_and_pad_nd(data[:, slice_idx], bbox, 0)
             seg_cropped = crop_and_pad_nd(seg[:, slice_idx], bbox, -1)
@@ -123,6 +124,8 @@ class FixedValTileManager:
                 seg_prev_cropped = crop_and_pad_nd(seg_prev[slice_idx], bbox, -1)
                 seg_cropped = np.concatenate((seg_cropped, seg_prev_cropped[None]), axis=0)
         else:
+            # crop_and_pad_nd expects one [start, end] interval per spatial axis.
+            # and our target size is self.patch_size
             bbox = [[i, i + j] for i, j in zip(starts, self.patch_size)]
             data_cropped = crop_and_pad_nd(data, bbox, 0)
             seg_cropped = crop_and_pad_nd(seg, bbox, -1)
@@ -150,6 +153,7 @@ class FixedValTileManager:
 
         data_batch = torch.stack(data_samples)
 
+        # Deep supervision transforms return one target per supervision scale.
         if isinstance(seg_samples[0], list):
             target_batch = [
                 torch.stack([sample[scale_idx] for sample in seg_samples])

--- a/nnunetv2/training/nnUNetTrainer/nnUNetTrainer.py
+++ b/nnunetv2/training/nnUNetTrainer/nnUNetTrainer.py
@@ -57,6 +57,7 @@ from nnunetv2.paths import nnUNet_preprocessed, nnUNet_results
 from nnunetv2.training.data_augmentation.compute_initial_patch_size import get_patch_size
 from nnunetv2.training.dataloading.nnunet_dataset import infer_dataset_class
 from nnunetv2.training.dataloading.data_loader import nnUNetDataLoader
+from nnunetv2.training.nnUNetTrainer.fixed_val_tiles import FixedValTileManager
 from nnunetv2.training.logging.nnunet_logger import MetaLogger
 from nnunetv2.training.loss.compound_losses import DC_and_CE_loss, DC_and_BCE_loss
 from nnunetv2.training.loss.deep_supervision import DeepSupervisionWrapper
@@ -159,6 +160,13 @@ class nnUNetTrainer(object):
         self.num_epochs = 1000
         self.current_epoch = 0
         self.enable_deep_supervision = True
+        self.use_fixed_val_tiles = True
+        self.fixed_val_tile_step_size = 0.5
+        # TODO: Fixing the seed is a design decision. Fabian Isensee for example likes nnU-Net's non-determinism
+        # (https://github.com/MIC-DKFZ/nnUNet/pull/2871#issuecomment-4243606104)
+        self.fixed_val_tile_seed = 42
+        self.fixed_val_num_tiles = None
+        self.fixed_val_manager: FixedValTileManager = None
 
         ### Dealing with labels/regions
         self.label_manager = self.plans_manager.get_label_manager(dataset_json)
@@ -270,6 +278,10 @@ class nnUNetTrainer(object):
                 "num_val_iterations_per_epoch": self.num_val_iterations_per_epoch,
                 "num_epochs": self.num_epochs,
                 "enable_deep_supervision": self.enable_deep_supervision,
+                "use_fixed_val_tiles": self.use_fixed_val_tiles,
+                "fixed_val_tile_step_size": self.fixed_val_tile_step_size,
+                "fixed_val_tile_seed": self.fixed_val_tile_seed,
+                "fixed_val_num_tiles": self.fixed_val_num_tiles,
                 "batch_size": self.configuration_manager.batch_size
                 }
             self.logger.update_config({"hparas": logger_config_hparas})
@@ -665,6 +677,55 @@ class nnUNetTrainer(object):
                                          folder_with_segs_from_previous_stage=self.folder_with_segs_from_previous_stage)
         return dataset_tr, dataset_val
 
+    def _register_fixed_val_logger_keys(self):
+        if not self.use_fixed_val_tiles:
+            return
+        logging_dict = self.logger.local_logger.my_fantastic_logging
+        if 'fixed_val_mean_fg_dice' not in logging_dict:
+            logging_dict['fixed_val_mean_fg_dice'] = list(logging_dict.get('mean_fg_dice', []))
+
+    def _build_fixed_validation_tile_manager(self) -> FixedValTileManager:
+        _, val_keys = self.do_split()
+        dataset_val = self.dataset_class(
+            self.preprocessed_dataset_folder,
+            val_keys,
+            folder_with_segs_from_previous_stage=self.folder_with_segs_from_previous_stage,
+        )
+
+        patch_size = tuple(int(i) for i in self.configuration_manager.patch_size)
+        global_batch_size = self.configuration_manager.batch_size if self.is_ddp else self.batch_size
+        default_num_tiles = self.num_val_iterations_per_epoch * global_batch_size
+        rank = dist.get_rank() if self.is_ddp else 0
+        world_size = dist.get_world_size() if self.is_ddp else 1
+        transforms = self.get_validation_transforms(
+            self._get_deep_supervision_scales(),
+            is_cascaded=self.is_cascaded,
+            foreground_labels=self.label_manager.foreground_labels,
+            regions=self.label_manager.foreground_regions if self.label_manager.has_regions else None,
+            ignore_label=self.label_manager.ignore_label,
+        )
+
+        manager = FixedValTileManager(
+            dataset=dataset_val,
+            patch_size=patch_size,
+            batch_size=self.batch_size,
+            transforms=transforms,
+            tile_step_size=self.fixed_val_tile_step_size,
+            seed=self.fixed_val_tile_seed,
+            num_tiles=self.fixed_val_num_tiles,
+            default_num_tiles=default_num_tiles,
+            is_ddp=self.is_ddp,
+            rank=rank,
+            world_size=world_size,
+        )
+        stats = manager.stats
+        self.print_to_log_file(
+            f"Fixed validation tile pool: {stats.num_cases} cases, {stats.num_candidate_tiles} candidate tiles, "
+            f"{stats.num_requested_tiles} requested tiles, {stats.num_selected_tiles} selected tiles, "
+            f"{stats.num_tiles_on_rank} tiles on rank {self.local_rank}",
+        )
+        return manager
+
     def get_dataloaders(self):
         if self.dataset_class is None:
             self.dataset_class = infer_dataset_class(self.preprocessed_dataset_folder)
@@ -693,12 +754,12 @@ class nnUNetTrainer(object):
             ignore_label=self.label_manager.ignore_label)
 
         # validation pipeline
-        val_transforms = self.get_validation_transforms(deep_supervision_scales,
-                                                        is_cascaded=self.is_cascaded,
-                                                        foreground_labels=self.label_manager.foreground_labels,
-                                                        regions=self.label_manager.foreground_regions if
-                                                        self.label_manager.has_regions else None,
-                                                        ignore_label=self.label_manager.ignore_label)
+        val_transforms = None if self.use_fixed_val_tiles else self.get_validation_transforms(
+            deep_supervision_scales,
+            is_cascaded=self.is_cascaded,
+            foreground_labels=self.label_manager.foreground_labels,
+            regions=self.label_manager.foreground_regions if self.label_manager.has_regions else None,
+            ignore_label=self.label_manager.ignore_label)
 
         dataset_tr, dataset_val = self.get_tr_and_val_datasets()
         dl_tr = nnUNetDataLoader(dataset_tr, self.batch_size,
@@ -708,31 +769,33 @@ class nnUNetTrainer(object):
                                  oversample_foreground_percent=self.oversample_foreground_percent,
                                  sampling_probabilities=None, pad_sides=None, transforms=tr_transforms,
                                  probabilistic_oversampling=self.probabilistic_oversampling)
-        dl_val = nnUNetDataLoader(dataset_val, self.batch_size,
-                                  self.configuration_manager.patch_size,
-                                  self.configuration_manager.patch_size,
-                                  self.label_manager,
-                                  oversample_foreground_percent=self.oversample_foreground_percent,
-                                  sampling_probabilities=None, pad_sides=None, transforms=val_transforms,
-                                  probabilistic_oversampling=self.probabilistic_oversampling)
+        dl_val = None if self.use_fixed_val_tiles else nnUNetDataLoader(
+            dataset_val, self.batch_size,
+            self.configuration_manager.patch_size,
+            self.configuration_manager.patch_size,
+            self.label_manager,
+            oversample_foreground_percent=self.oversample_foreground_percent,
+            sampling_probabilities=None, pad_sides=None, transforms=val_transforms,
+            probabilistic_oversampling=self.probabilistic_oversampling)
 
         allowed_num_processes = get_allowed_n_proc_DA()
         if allowed_num_processes == 0:
             mt_gen_train = SingleThreadedAugmenter(dl_tr, None)
-            mt_gen_val = SingleThreadedAugmenter(dl_val, None)
+            mt_gen_val = None if self.use_fixed_val_tiles else SingleThreadedAugmenter(dl_val, None)
         else:
             mt_gen_train = NonDetMultiThreadedAugmenter(data_loader=dl_tr, transform=None,
                                                         num_processes=allowed_num_processes,
                                                         num_cached=max(6, allowed_num_processes // 2), seeds=None,
                                                         pin_memory=self.device.type == 'cuda', wait_time=0.002)
-            mt_gen_val = NonDetMultiThreadedAugmenter(data_loader=dl_val,
-                                                      transform=None, num_processes=max(1, allowed_num_processes // 2),
-                                                      num_cached=max(3, allowed_num_processes // 4), seeds=None,
-                                                      pin_memory=self.device.type == 'cuda',
-                                                      wait_time=0.002)
+            mt_gen_val = None if self.use_fixed_val_tiles else NonDetMultiThreadedAugmenter(
+                data_loader=dl_val, transform=None, num_processes=max(1, allowed_num_processes // 2),
+                num_cached=max(3, allowed_num_processes // 4), seeds=None,
+                pin_memory=self.device.type == 'cuda',
+                wait_time=0.002)
         # # let's get this party started
         _ = next(mt_gen_train)
-        _ = next(mt_gen_val)
+        if mt_gen_val is not None:
+            _ = next(mt_gen_val)
         return mt_gen_train, mt_gen_val
 
     @staticmethod
@@ -964,6 +1027,10 @@ class nnUNetTrainer(object):
         if self.is_ddp:
             dist.barrier()
 
+        if self.use_fixed_val_tiles:
+            self._register_fixed_val_logger_keys()
+            self.fixed_val_manager = self._build_fixed_validation_tile_manager()
+
         # copy plans and dataset.json so that they can be used for restoring everything we need for inference
         save_json(self.plans_manager.plans, join(self.output_folder_base, 'plans.json'), sort_keys=False)
         save_json(self.dataset_json, join(self.output_folder_base, 'dataset.json'), sort_keys=False)
@@ -1162,6 +1229,8 @@ class nnUNetTrainer(object):
         self.logger.log('mean_fg_dice', mean_fg_dice, self.current_epoch)
         self.logger.log('dice_per_class_or_region', global_dc_per_class, self.current_epoch)
         self.logger.log('val_losses', loss_here, self.current_epoch)
+        if self.use_fixed_val_tiles:
+            self.logger.log('fixed_val_mean_fg_dice', mean_fg_dice, self.current_epoch)
 
     def on_epoch_start(self):
         self.logger.log('epoch_start_timestamps', time(), self.current_epoch)
@@ -1181,10 +1250,16 @@ class nnUNetTrainer(object):
         if (current_epoch + 1) % self.save_every == 0 and current_epoch != (self.num_epochs - 1):
             self.save_checkpoint(join(self.output_folder, 'checkpoint_latest.pth'))
 
-        # handle 'best' checkpointing. ema_fg_dice is computed by the logger and can be accessed like this
-        if self._best_ema is None or self.logger.get_value('ema_fg_dice', step=-1) > self._best_ema:
-            self._best_ema = self.logger.get_value('ema_fg_dice', step=-1)
-            self.print_to_log_file(f"Yayy! New best EMA pseudo Dice: {np.round(self._best_ema, decimals=4)}")
+        # handle 'best' checkpointing. ema_fg_dice is computed by the logger and can be accessed like this.
+        # With fixed validation tiles, raw fixed-val Dice is comparable across epochs; EMA would only add lag.
+        current_score = self.logger.get_value('fixed_val_mean_fg_dice' if self.use_fixed_val_tiles else 'ema_fg_dice',
+                                              step=-1)
+        if self._best_ema is None or current_score > self._best_ema:
+            self._best_ema = current_score
+            if self.use_fixed_val_tiles:
+                self.print_to_log_file(f"New best pseudo Dice: {float(self._best_ema):.4f}")
+            else:
+                self.print_to_log_file(f"Yayy! New best EMA pseudo Dice: {np.round(self._best_ema, decimals=4)}")
             self.save_checkpoint(join(self.output_folder, 'checkpoint_best.pth'))
 
         if self.local_rank == 0:
@@ -1235,6 +1310,7 @@ class nnUNetTrainer(object):
         self.my_init_kwargs = checkpoint['init_args']
         self.current_epoch = checkpoint['current_epoch']
         self.logger.load_checkpoint(checkpoint['logging'])
+        self._register_fixed_val_logger_keys()
         self._best_ema = checkpoint['_best_ema']
         self.inference_allowed_mirroring_axes = checkpoint[
             'inference_allowed_mirroring_axes'] if 'inference_allowed_mirroring_axes' in checkpoint.keys() else self.inference_allowed_mirroring_axes
@@ -1429,8 +1505,12 @@ class nnUNetTrainer(object):
             with torch.no_grad():
                 self.on_validation_epoch_start()
                 val_outputs = []
-                for batch_id in range(self.num_val_iterations_per_epoch):
-                    val_outputs.append(self.validation_step(next(self.dataloader_val)))
+                if self.use_fixed_val_tiles:
+                    for batch in self.fixed_val_manager.iter_batches():
+                        val_outputs.append(self.validation_step(batch))
+                else:
+                    for batch_id in range(self.num_val_iterations_per_epoch):
+                        val_outputs.append(self.validation_step(next(self.dataloader_val)))
                 self.on_validation_epoch_end(val_outputs)
 
             self.on_epoch_end()

--- a/nnunetv2/training/nnUNetTrainer/nnUNetTrainer.py
+++ b/nnunetv2/training/nnUNetTrainer/nnUNetTrainer.py
@@ -687,7 +687,9 @@ class nnUNetTrainer(object):
 
         patch_size = tuple(int(i) for i in self.configuration_manager.patch_size)
         global_batch_size = self.configuration_manager.batch_size if self.is_ddp else self.batch_size
-        default_num_tiles = self.num_val_iterations_per_epoch * global_batch_size
+        num_tiles = self.fixed_val_num_tiles
+        if num_tiles is None:
+            num_tiles = self.num_val_iterations_per_epoch * global_batch_size
         rank = dist.get_rank() if self.is_ddp else 0
         world_size = dist.get_world_size() if self.is_ddp else 1
         transforms = self.get_validation_transforms(
@@ -705,8 +707,7 @@ class nnUNetTrainer(object):
             transforms=transforms,
             tile_step_size=self.fixed_val_tile_step_size,
             seed=self.fixed_val_tile_seed,
-            num_tiles=self.fixed_val_num_tiles,
-            default_num_tiles=default_num_tiles,
+            num_tiles=num_tiles,
             is_ddp=self.is_ddp,
             rank=rank,
             world_size=world_size,

--- a/nnunetv2/training/nnUNetTrainer/nnUNetTrainer.py
+++ b/nnunetv2/training/nnUNetTrainer/nnUNetTrainer.py
@@ -747,12 +747,12 @@ class nnUNetTrainer(object):
             ignore_label=self.label_manager.ignore_label)
 
         # validation pipeline
-        val_transforms = None if self.use_fixed_val_tiles else self.get_validation_transforms(
-            deep_supervision_scales,
-            is_cascaded=self.is_cascaded,
-            foreground_labels=self.label_manager.foreground_labels,
-            regions=self.label_manager.foreground_regions if self.label_manager.has_regions else None,
-            ignore_label=self.label_manager.ignore_label)
+        val_transforms = self.get_validation_transforms(deep_supervision_scales,
+                                                        is_cascaded=self.is_cascaded,
+                                                        foreground_labels=self.label_manager.foreground_labels,
+                                                        regions=self.label_manager.foreground_regions if
+                                                        self.label_manager.has_regions else None,
+                                                        ignore_label=self.label_manager.ignore_label)
 
         dataset_tr, dataset_val = self.get_tr_and_val_datasets()
         dl_tr = nnUNetDataLoader(dataset_tr, self.batch_size,
@@ -762,33 +762,31 @@ class nnUNetTrainer(object):
                                  oversample_foreground_percent=self.oversample_foreground_percent,
                                  sampling_probabilities=None, pad_sides=None, transforms=tr_transforms,
                                  probabilistic_oversampling=self.probabilistic_oversampling)
-        dl_val = None if self.use_fixed_val_tiles else nnUNetDataLoader(
-            dataset_val, self.batch_size,
-            self.configuration_manager.patch_size,
-            self.configuration_manager.patch_size,
-            self.label_manager,
-            oversample_foreground_percent=self.oversample_foreground_percent,
-            sampling_probabilities=None, pad_sides=None, transforms=val_transforms,
-            probabilistic_oversampling=self.probabilistic_oversampling)
+        dl_val = nnUNetDataLoader(dataset_val, self.batch_size,
+                                  self.configuration_manager.patch_size,
+                                  self.configuration_manager.patch_size,
+                                  self.label_manager,
+                                  oversample_foreground_percent=self.oversample_foreground_percent,
+                                  sampling_probabilities=None, pad_sides=None, transforms=val_transforms,
+                                  probabilistic_oversampling=self.probabilistic_oversampling)
 
         allowed_num_processes = get_allowed_n_proc_DA()
         if allowed_num_processes == 0:
             mt_gen_train = SingleThreadedAugmenter(dl_tr, None)
-            mt_gen_val = None if self.use_fixed_val_tiles else SingleThreadedAugmenter(dl_val, None)
+            mt_gen_val = SingleThreadedAugmenter(dl_val, None)
         else:
             mt_gen_train = NonDetMultiThreadedAugmenter(data_loader=dl_tr, transform=None,
                                                         num_processes=allowed_num_processes,
                                                         num_cached=max(6, allowed_num_processes // 2), seeds=None,
                                                         pin_memory=self.device.type == 'cuda', wait_time=0.002)
-            mt_gen_val = None if self.use_fixed_val_tiles else NonDetMultiThreadedAugmenter(
-                data_loader=dl_val, transform=None, num_processes=max(1, allowed_num_processes // 2),
-                num_cached=max(3, allowed_num_processes // 4), seeds=None,
-                pin_memory=self.device.type == 'cuda',
-                wait_time=0.002)
+            mt_gen_val = NonDetMultiThreadedAugmenter(data_loader=dl_val,
+                                                      transform=None, num_processes=max(1, allowed_num_processes // 2),
+                                                      num_cached=max(3, allowed_num_processes // 4), seeds=None,
+                                                      pin_memory=self.device.type == 'cuda',
+                                                      wait_time=0.002)
         # # let's get this party started
         _ = next(mt_gen_train)
-        if mt_gen_val is not None:
-            _ = next(mt_gen_val)
+        _ = next(mt_gen_val)
         return mt_gen_train, mt_gen_val
 
     @staticmethod

--- a/nnunetv2/training/nnUNetTrainer/nnUNetTrainer.py
+++ b/nnunetv2/training/nnUNetTrainer/nnUNetTrainer.py
@@ -677,13 +677,6 @@ class nnUNetTrainer(object):
                                          folder_with_segs_from_previous_stage=self.folder_with_segs_from_previous_stage)
         return dataset_tr, dataset_val
 
-    def _register_fixed_val_logger_keys(self):
-        if not self.use_fixed_val_tiles:
-            return
-        logging_dict = self.logger.local_logger.my_fantastic_logging
-        if 'fixed_val_mean_fg_dice' not in logging_dict:
-            logging_dict['fixed_val_mean_fg_dice'] = list(logging_dict.get('mean_fg_dice', []))
-
     def _build_fixed_validation_tile_manager(self) -> FixedValTileManager:
         _, val_keys = self.do_split()
         dataset_val = self.dataset_class(
@@ -1028,7 +1021,6 @@ class nnUNetTrainer(object):
             dist.barrier()
 
         if self.use_fixed_val_tiles:
-            self._register_fixed_val_logger_keys()
             self.fixed_val_manager = self._build_fixed_validation_tile_manager()
 
         # copy plans and dataset.json so that they can be used for restoring everything we need for inference
@@ -1229,8 +1221,6 @@ class nnUNetTrainer(object):
         self.logger.log('mean_fg_dice', mean_fg_dice, self.current_epoch)
         self.logger.log('dice_per_class_or_region', global_dc_per_class, self.current_epoch)
         self.logger.log('val_losses', loss_here, self.current_epoch)
-        if self.use_fixed_val_tiles:
-            self.logger.log('fixed_val_mean_fg_dice', mean_fg_dice, self.current_epoch)
 
     def on_epoch_start(self):
         self.logger.log('epoch_start_timestamps', time(), self.current_epoch)
@@ -1252,7 +1242,7 @@ class nnUNetTrainer(object):
 
         # handle 'best' checkpointing. ema_fg_dice is computed by the logger and can be accessed like this.
         # With fixed validation tiles, raw fixed-val Dice is comparable across epochs; EMA would only add lag.
-        current_score = self.logger.get_value('fixed_val_mean_fg_dice' if self.use_fixed_val_tiles else 'ema_fg_dice',
+        current_score = self.logger.get_value('mean_fg_dice' if self.use_fixed_val_tiles else 'ema_fg_dice',
                                               step=-1)
         if self._best_ema is None or current_score > self._best_ema:
             self._best_ema = current_score
@@ -1310,7 +1300,6 @@ class nnUNetTrainer(object):
         self.my_init_kwargs = checkpoint['init_args']
         self.current_epoch = checkpoint['current_epoch']
         self.logger.load_checkpoint(checkpoint['logging'])
-        self._register_fixed_val_logger_keys()
         self._best_ema = checkpoint['_best_ema']
         self.inference_allowed_mirroring_axes = checkpoint[
             'inference_allowed_mirroring_axes'] if 'inference_allowed_mirroring_axes' in checkpoint.keys() else self.inference_allowed_mirroring_axes

--- a/nnunetv2/training/nnUNetTrainer/nnUNetTrainer.py
+++ b/nnunetv2/training/nnUNetTrainer/nnUNetTrainer.py
@@ -57,7 +57,7 @@ from nnunetv2.paths import nnUNet_preprocessed, nnUNet_results
 from nnunetv2.training.data_augmentation.compute_initial_patch_size import get_patch_size
 from nnunetv2.training.dataloading.nnunet_dataset import infer_dataset_class
 from nnunetv2.training.dataloading.data_loader import nnUNetDataLoader
-from nnunetv2.training.nnUNetTrainer.fixed_val_tiles import FixedValTileManager
+from nnunetv2.utilities.fixed_val_tiles import FixedValTileManager
 from nnunetv2.training.logging.nnunet_logger import MetaLogger
 from nnunetv2.training.loss.compound_losses import DC_and_CE_loss, DC_and_BCE_loss
 from nnunetv2.training.loss.deep_supervision import DeepSupervisionWrapper

--- a/nnunetv2/utilities/fixed_val_tiles.py
+++ b/nnunetv2/utilities/fixed_val_tiles.py
@@ -117,20 +117,20 @@ class FixedValTileManager:
             spatial_starts = starts[1:]
             # crop_and_pad_nd expects one [start, end] interval per spatial axis
             # and our target size is self.patch_size.
-            bbox = [[i, i + j] for i, j in zip(spatial_starts, self.patch_size)]
-            data_cropped = crop_and_pad_nd(data[:, slice_idx], bbox, 0)
-            seg_cropped = crop_and_pad_nd(seg[:, slice_idx], bbox, -1)
+            bbox = [[slice_idx, slice_idx + 1], *[[i, i + j] for i, j in zip(spatial_starts, self.patch_size)]]
+            data_cropped = crop_and_pad_nd(data, bbox, 0)[:, 0]
+            seg_cropped = crop_and_pad_nd(seg, bbox, -1, cast_cropped_to=np.int16)[:, 0]
             if seg_prev is not None:
-                seg_prev_cropped = crop_and_pad_nd(seg_prev[slice_idx], bbox, -1)
+                seg_prev_cropped = crop_and_pad_nd(seg_prev, bbox, -1, cast_cropped_to=np.int16)[0]
                 seg_cropped = np.concatenate((seg_cropped, seg_prev_cropped[None]), axis=0)
         else:
             # crop_and_pad_nd expects one [start, end] interval per spatial axis
             # and our target size is self.patch_size.
             bbox = [[i, i + j] for i, j in zip(starts, self.patch_size)]
             data_cropped = crop_and_pad_nd(data, bbox, 0)
-            seg_cropped = crop_and_pad_nd(seg, bbox, -1)
+            seg_cropped = crop_and_pad_nd(seg, bbox, -1, cast_cropped_to=np.int16)
             if seg_prev is not None:
-                seg_prev_cropped = crop_and_pad_nd(seg_prev, bbox, -1)
+                seg_prev_cropped = crop_and_pad_nd(seg_prev, bbox, -1, cast_cropped_to=np.int16)
                 seg_cropped = np.concatenate((seg_cropped, seg_prev_cropped[None]), axis=0)
 
         return torch.from_numpy(data_cropped).float(), torch.from_numpy(seg_cropped).to(torch.int16)
@@ -141,11 +141,6 @@ class FixedValTileManager:
 
         for tile in tiles:
             data, seg, seg_prev, _ = self.dataset.load_case(tile.key)
-            data = np.asarray(data[:])
-            seg = np.asarray(seg[:])
-            if seg_prev is not None:
-                seg_prev = np.asarray(seg_prev[:])
-
             data_cropped, seg_cropped = self._crop_tile(data, seg, seg_prev, tile.starts)
             transformed = self.transforms(image=data_cropped, segmentation=seg_cropped)
             data_samples.append(transformed['image'])


### PR DESCRIPTION
Hey nnU-Net Team,

I have been using nnU-Net extensively, thank you for providing and maintaining such an awesome project!

# The Problem

nnU-Net tends to overfit on some datasets. To help with this, one can sometimes use `--val_best`, but as I understand it, this is not generally recommended ([1](https://github.com/MIC-DKFZ/nnUNet/issues/2754#issuecomment-2766015379), [2](https://github.com/MIC-DKFZ/nnUNet/blob/2026b8e0652886508a75df0b2f5b95dd252bec54/nnunetv2/run/run_training.py#L233), [3](https://github.com/MIC-DKFZ/nnUNet/issues/3010#issuecomment-4206273449)).

This is because:

1. It uses pseudo Dice, which is a biased metric, since it samples based on `oversample_foreground_percent`.
2. Since this signal is noisy, it needs smoothing, which makes the value "lag". However, nnU-Net's training, and thus model performance, is inherently noisy from epoch to epoch.

# The Idea

The idea here is to replace nnU-Net's default validation strategy by selecting a fixed subset of all sliding-window tiles from the final validation, and then evaluating on that fixed subset. This tries to address:

1. the sampling bias by using fair random sampling, and
2. the noisy signal by making the validation subset comparable from epoch to epoch.

# Experiments

I ran these experiments on datasets where I had already trained models for 1000 epochs in ([4](https://arxiv.org/pdf/2511.17146)). These use the `noSmooth` trainer variants, but that should not matter too much. The table below shows the Dice scores for both runs: the old default run and the new run using the proposed `val_best` strategy.

| Dataset | Old run | Old run | New run | New run | Old Δ | New Δ |
|---|---:|---:|---:|---:|---:|---:|
|  | Final | Best | Final | Best | Best - Final | Best - Final |
| WMH | 77.11 | 78.06 | 78.46 | 80.15 | +0.95 | **+1.69** |
| SBM | 67.49 | 68.31 | 66.40 | 69.25 | +0.82 | **+2.85** |

These runs are not perfectly comparable, since nnU-Net training is not deterministic. Still, the new best-model selection shows larger within-run gains than the previous strategy: +1.69 and +2.85 Dice points compared to +0.95 and +0.82.

I am of course always open to discussion, so let me know what you think! This will need more extensive evaluation on different datasets (any experiments welcome! :)) and different model architectures. For example, I think the PrimusV2/V3 trainers could also greatly benefit from this, since I have noticed them having a stronger tendency to overfit.

Kind regards,

Luc


Disclaimer: Parts of the code in this PR were written with the help of Codex.