### PR TITLE
[FIX] patch sampling in get_bbox() method to ensure patches are always fully contained inside the volume when oversampling foreground

### DIFF
--- a/nnunetv2/training/dataloading/data_loader.py
+++ b/nnunetv2/training/dataloading/data_loader.py
@@ -142,7 +142,7 @@ class nnUNetDataLoader(DataLoader):
                 # selected voxel is center voxel. Subtract half the patch size to get lower bbox voxel.
                 # Make sure it is within the bounds of lb and ub
                 # i + 1 because we have first dimension 0!
-                bbox_lbs = [max(lbs[i], selected_voxel[i + 1] - self.patch_size[i] // 2) for i in range(dim)]
+                bbox_lbs = [max(lbs[i], min(ubs[i], selected_voxel[i + 1] - self.patch_size[i] // 2)) for i in range(dim)]
             else:
                 # If the image does not contain any foreground classes, we fall back to random cropping
                 bbox_lbs = [np.random.randint(lbs[i], ubs[i] + 1) for i in range(dim)]


### PR DESCRIPTION
Hey all,

Thanks a lot for all the work that has gone into nnU-Net over the years!

I believe I found a bug in patch sampling when visualizing 3D CT batches (AMOS dataset), where some sampled patches contain slices outside the scan field-of-view (resulting in unexpected padding).

The issue occurs in the `get_bbox()` method when `force_fg=True` (foreground oversampling). In this case, a foreground class is first selected, then a random voxel from that class is chosen as the patch center. However, when constructing the patch, the resulting bounding box is only constrained with respect to the lower bounds (`lbs`) and is not checked against the upper bounds (`ubs`), which define the valid sampling range to keep the patch fully inside the volume (here: https://github.com/MIC-DKFZ/nnUNet/blob/e73bbc743f93877211ca434dd07eca07c1221d0b/nnunetv2/training/dataloading/data_loader.py#L145). As a consequence, some foreground patches may partially fall outside the valid image region and become padded.

Note that this issue does not occur when `force_fg=False`, since `bbox_lbs` is sampled directly within the valid interval `[lbs, ubs]`.

The proposed fix explicitly constrains the sampled bounding box to remain within both `lbs` and `ubs`, which fixes the issue in my tests.

Below is a small GIF illustrating the problem (see the 3rd sample: some slices lie outside the scan field-of-view and are therefore padded unexpectedly).

<img width="1956" height="514" alt="batches-nnunet-pr" src="https://github.com/user-attachments/assets/e143952b-cac2-4301-a53f-a2e7e00e376c" />