### PR TITLE
Add deep ensemble split utility

### DIFF
--- a/documentation/deep_ensemble.md
+++ b/documentation/deep_ensemble.md
@@ -1,0 +1,150 @@
+# Deep Ensemble with nnU-Net
+
+nnU-Net's standard cross-validation folds are useful for model selection, performance estimation, and test-time ensembling. However, a cross-validation (CV) ensemble is not the same as a deep ensemble (DE) for uncertainty estimation [1].
+
+In a deep ensemble, all members are trained on the same training set, but with different random initializations and stochastic training trajectories [2]. In a CV ensemble, individual models are trained on different training subsets. As a result, CV ensemble disagreement reflects not only model uncertainty, but also differences caused by incomplete or varying data exposure [1].
+
+`nnUNetv2_create_deep_ensemble_splits` provides a lightweight way to train DE members within the existing nnU-Net fold infrastructure. It appends full-training-set folds to `splits_final.json`. These folds can then be trained with the standard command:
+
+```bash
+nnUNetv2_train DATASET CONFIGURATION FOLD
+```
+
+This utility does not change nnU-Net training, checkpointing, inference defaults, or model selection defaults.
+
+## Workflow
+
+### 1. Plan and preprocess the dataset
+
+```bash
+nnUNetv2_plan_and_preprocess -d DATASET_ID --verify_dataset_integrity
+```
+
+### 2. Create cross-validation and deep ensemble splits
+
+Create the standard CV folds, if needed, and append deep ensemble folds:
+
+```bash
+nnUNetv2_create_deep_ensemble_splits DATASET_ID 3d_fullres --num_members 5
+```
+
+This preserves existing non-deep-ensemble splits and appends the requested number of deep ensemble folds.
+
+### 3. Train the CV folds
+
+Use the standard CV folds for model selection and performance estimation:
+
+```bash
+for f in 0 1 2 3 4; do
+    nnUNetv2_train DATASET_ID 3d_fullres $f --npz
+done
+```
+
+### 4. Run model selection on CV folds only
+
+```bash
+nnUNetv2_find_best_configuration DATASET_ID -f 0 1 2 3 4
+```
+
+Do not include DE folds in model selection, because they are trained on the full training set.
+
+### 5. Train the deep ensemble folds
+
+For example, if the dataset has five standard CV folds and five deep ensemble folds were appended, the deep ensemble folds will be `5 6 7 8 9`:
+
+```bash
+for f in 5 6 7 8 9; do
+    nnUNetv2_train DATASET_ID 3d_fullres $f
+done
+```
+
+### 6. Predict with the deep ensemble
+
+Explicitly select the deep ensemble folds at inference time:
+
+```bash
+nnUNetv2_predict \
+    -d DATASET_ID \
+    -c 3d_fullres \
+    -i INPUT_FOLDER \
+    -o OUTPUT_FOLDER \
+    -f 5 6 7 8 9
+```
+
+## Fold indexing
+
+If there are already `K` existing non-deep-ensemble folds and you request `N` deep ensemble members, the appended deep ensemble folds will be:
+
+```text
+K, K + 1, ..., K + N - 1
+```
+
+For example:
+
+- existing CV folds: `0 1 2 3 4`
+- requested deep ensemble members: `N = 3`
+- appended deep ensemble folds: `5 6 7`
+
+The `deep_ensemble_member` metadata stored in `splits_final.json` is 0-based.
+
+## Existing split files
+
+Existing split files do not need to contain exactly five folds.
+
+If `splits_final.json` already exists, all non-deep-ensemble splits are preserved exactly. In this case, `--num_cv_folds` is ignored. The `--num_cv_folds` argument is only used when no split file exists and the utility needs to create the initial cross-validation splits.
+
+Existing deep ensemble splits are not overwritten by default. To replace them, use `--overwrite_deep_ensemble_splits`.
+
+## Important validation warning
+
+Deep ensemble folds use all available training cases for both `train` and `val` in `splits_final.json`. This is done for compatibility with the existing nnU-Net fold pipeline.
+
+Validation metrics from these folds are biased and must **not** be used for model selection or performance estimation.
+
+Use:
+
+- standard CV folds for model selection and performance estimation;
+- deep ensemble folds for final full-data ensemble training.
+
+## Inference
+
+This utility does not change nnU-Net inference behavior. `nnUNetv2_predict` will not automatically use deep ensemble folds. The desired folds must be passed explicitly with `-f`.
+
+For example:
+
+```bash
+nnUNetv2_predict \
+    -d DATASET_ID \
+    -c 3d_fullres \
+    -i INPUT_FOLDER \
+    -o OUTPUT_FOLDER \
+    -f 5 6 7 8 9
+```
+
+*If you need per-member predictions or probabilities for custom uncertainty analysis, run prediction separately for each deep ensemble fold and aggregate the outputs externally.*
+
+## Recommendation
+
+Deep ensembles and CV ensembles should not be treated as interchangeable uncertainty estimators [1]. Use CV folds for model selection and unbiased performance estimation. Use deep ensemble folds when the goal is to train a final full-data ensemble for uncertainty estimation.
+
+## Citation
+
+If you use Deep Ensemble within nnU-Net in your work, please cite [1]:
+
+```bibtex
+@misc{kirscher2026lostinfolds,
+      title={Lost in the Folds: When Cross-Validation Is Not a Deep Ensemble for Uncertainty Estimation}, 
+      author={Tristan Kirscher and Markus Bujotzek and Yannick Kirchhoff and Maximilian Rokuss and Fabian Isensee and Kim-Celine Kahl and Balint Kovacs and Klaus Maier-Hein},
+      year={2026},
+      eprint={2605.18329},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV},
+      url={https://arxiv.org/abs/2605.18329}, 
+}
+```
+
+## References
+
+[1] Kirscher et al. *Lost in the Folds: When Cross-Validation Is Not a Deep Ensemble for Uncertainty Estimation*. MICCAI, 2026.
+
+[2] Lakshminarayanan et al. *Simple and Scalable Predictive Uncertainty Estimation using Deep Ensembles*. NeurIPS, 2017.

--- a/documentation/deep_ensemble.md
+++ b/documentation/deep_ensemble.md
@@ -50,7 +50,7 @@ Do not include DE folds in model selection, because they are trained on the full
 
 ### 5. Train the deep ensemble folds
 
-For example, if the dataset has five standard CV folds and five deep ensemble folds were appended, the deep ensemble folds will be `5 6 7 8 9`:
+For example, if the dataset has five standard CV folds and five deep ensemble folds were appended, the deep ensemble folds will be `5 6 7 8 9`. These indices depend on the number of existing non-deep-ensemble folds; see [Fold indexing](#fold-indexing) below.
 
 ```bash
 for f in 5 6 7 8 9; do

--- a/documentation/reference/cli-overview.md
+++ b/documentation/reference/cli-overview.md
@@ -43,6 +43,7 @@ This page groups the main nnU-Net v2 command-line entry points by workflow stage
 
 - `nnUNetv2_move_plans_between_datasets`: reuse plans across datasets
 - `nnUNetv2_plot_overlay_pngs`: create overlay PNGs for visualization
+- `nnUNetv2_create_deep_ensemble_splits`: append full-training-set folds for [deep ensemble training](../deep_ensemble.md)
 
 ## Help and discovery
 

--- a/nnunetv2/evaluation/find_best_configuration.py
+++ b/nnunetv2/evaluation/find_best_configuration.py
@@ -4,7 +4,7 @@ from copy import deepcopy
 from typing import Union, List, Tuple
 
 from batchgenerators.utilities.file_and_folder_operations import (
-    load_json, join, isdir, listdir, save_json
+    load_json, join, isdir, isfile, listdir, save_json
 )
 from nnunetv2.configuration import default_num_processes
 from nnunetv2.ensembling.ensemble import ensemble_crossvalidations
@@ -14,6 +14,7 @@ from nnunetv2.paths import nnUNet_preprocessed, nnUNet_results
 from nnunetv2.postprocessing.remove_connected_components import determine_postprocessing
 from nnunetv2.utilities.file_path_utilities import maybe_convert_to_dataset_name, get_output_folder, \
     convert_identifier_to_trainer_plans_config, get_ensemble_name, folds_tuple_to_string
+from nnunetv2.utilities.deep_ensemble_splits import get_deep_ensemble_fold_indices
 from nnunetv2.utilities.plans_handling.plans_handler import PlansManager
 
 default_trained_models = tuple([
@@ -22,6 +23,20 @@ default_trained_models = tuple([
     {'plans': 'nnUNetPlans', 'configuration': '3d_lowres', 'trainer': 'nnUNetTrainer'},
     {'plans': 'nnUNetPlans', 'configuration': '3d_cascade_fullres', 'trainer': 'nnUNetTrainer'},
 ])
+
+
+def maybe_warn_about_deep_ensemble_folds(dataset_name_or_id: Union[str, int], folds: Union[List[int], Tuple[int, ...]]):
+    splits_file = join(nnUNet_preprocessed, maybe_convert_to_dataset_name(dataset_name_or_id), 'splits_final.json')
+    if not isfile(splits_file):
+        return
+    splits = load_json(splits_file)
+    if not isinstance(splits, list):
+        return
+    deep_ensemble_folds = get_deep_ensemble_fold_indices(splits, folds)
+    if len(deep_ensemble_folds) > 0:
+        print(f'WARNING: Requested folds include deep ensemble folds {deep_ensemble_folds}. Their validation metrics '
+              f'are biased because they use all training cases. Do not use them for model selection or performance '
+              f'estimation.')
 
 
 def filter_available_models(model_dict: Union[List[dict], Tuple[dict, ...]], dataset_name_or_id: Union[str, int]):
@@ -88,6 +103,8 @@ def find_best_configuration(dataset_name_or_id,
                             strict: bool = False):
     dataset_name = maybe_convert_to_dataset_name(dataset_name_or_id)
     all_results = {}
+
+    maybe_warn_about_deep_ensemble_folds(dataset_name_or_id, folds)
 
     allowed_trained_models = filter_available_models(deepcopy(allowed_trained_models), dataset_name_or_id)
 

--- a/nnunetv2/evaluation/find_best_configuration.py
+++ b/nnunetv2/evaluation/find_best_configuration.py
@@ -1,7 +1,7 @@
 import argparse
 import os.path
 from copy import deepcopy
-from typing import Union, List, Tuple
+from typing import Union, List, Tuple, Optional
 
 from batchgenerators.utilities.file_and_folder_operations import (
     load_json, join, isdir, isfile, listdir, save_json
@@ -25,7 +25,8 @@ default_trained_models = tuple([
 ])
 
 
-def maybe_warn_about_deep_ensemble_folds(dataset_name_or_id: Union[str, int], folds: Union[List[int], Tuple[int, ...]]):
+def maybe_warn_about_deep_ensemble_folds(dataset_name_or_id: Union[str, int],
+                                         folds: Optional[Union[List[int], Tuple[int, ...]]]):
     splits_file = join(nnUNet_preprocessed, maybe_convert_to_dataset_name(dataset_name_or_id), 'splits_final.json')
     if not isfile(splits_file):
         return
@@ -101,6 +102,10 @@ def find_best_configuration(dataset_name_or_id,
                             overwrite: bool = True,
                             folds: Union[List[int], Tuple[int, ...]] = (0, 1, 2, 3, 4),
                             strict: bool = False):
+    if folds is None:
+        raise ValueError("folds must be a list or tuple of fold indices. None is only supported when checking "
+                         "splits for deep ensemble folds.")
+
     dataset_name = maybe_convert_to_dataset_name(dataset_name_or_id)
     all_results = {}
 

--- a/nnunetv2/tests/test_deep_ensemble_splits.py
+++ b/nnunetv2/tests/test_deep_ensemble_splits.py
@@ -1,0 +1,91 @@
+import json
+import unittest
+from copy import deepcopy
+
+from nnunetv2.utilities.deep_ensemble_splits import create_or_update_deep_ensemble_splits
+
+
+class TestDeepEnsembleSplits(unittest.TestCase):
+    def test_creates_cv_splits_and_appends_deep_ensemble_splits(self):
+        cases = ["case_003", "case_001", "case_002", "case_004", "case_000", "case_005"]
+
+        splits = create_or_update_deep_ensemble_splits(
+            None, cases, num_members=2, num_cv_folds=3, seed=12345)
+
+        self.assertEqual(len(splits), 5)
+        self.assertTrue(all("deep_ensemble" not in s for s in splits[:3]))
+
+        all_cases = sorted(cases)
+        for member, split in enumerate(splits[3:]):
+            self.assertEqual(split["train"], all_cases)
+            self.assertEqual(split["val"], all_cases)
+            self.assertTrue(split["deep_ensemble"])
+            self.assertEqual(split["deep_ensemble_member"], member)
+
+    def test_preserves_existing_non_deep_ensemble_splits(self):
+        existing_splits = [
+            {"train": ["case_001", "case_002"], "val": ["case_000"], "custom": {"keep": True}},
+            {"train": ["case_000", "case_002"], "val": ["case_001"]},
+        ]
+        expected_existing_splits = deepcopy(existing_splits)
+
+        splits = create_or_update_deep_ensemble_splits(
+            existing_splits, ["case_002", "case_000", "case_001"], num_members=2)
+
+        self.assertEqual(splits[:2], expected_existing_splits)
+        self.assertEqual(len(splits), 4)
+        self.assertTrue(all(s["deep_ensemble"] for s in splits[2:]))
+        self.assertEqual(splits[2]["train"], ["case_000", "case_001", "case_002"])
+
+    def test_existing_split_count_does_not_need_to_be_five(self):
+        existing_splits = [
+            {"train": ["case_001", "case_002"], "val": ["case_000"]},
+            {"train": ["case_000", "case_002"], "val": ["case_001"]},
+            {"train": ["case_000", "case_001"], "val": ["case_002"]},
+        ]
+        expected_existing_splits = deepcopy(existing_splits)
+
+        splits = create_or_update_deep_ensemble_splits(
+            existing_splits, ["case_002", "case_000", "case_001"], num_members=2, num_cv_folds=5)
+
+        self.assertEqual(splits[:3], expected_existing_splits)
+        self.assertEqual(len(splits), 5)
+        self.assertEqual(splits[3]["deep_ensemble_member"], 0)
+        self.assertEqual(splits[4]["deep_ensemble_member"], 1)
+        self.assertEqual(splits[3]["train"], ["case_000", "case_001", "case_002"])
+        self.assertEqual(splits[4]["val"], ["case_000", "case_001", "case_002"])
+
+    def test_existing_deep_ensemble_splits_raise_unless_overwrite_enabled(self):
+        existing_splits = [
+            {"train": ["case_000"], "val": ["case_001"]},
+            {"train": ["old"], "val": ["old"], "deep_ensemble": True, "deep_ensemble_member": 7},
+            {"train": ["case_001"], "val": ["case_000"], "note": "preserve"},
+        ]
+
+        with self.assertRaisesRegex(RuntimeError, "deep ensemble splits"):
+            create_or_update_deep_ensemble_splits(existing_splits, ["case_000", "case_001"], num_members=1)
+
+        splits = create_or_update_deep_ensemble_splits(
+            existing_splits, ["case_001", "case_000"], num_members=2,
+            overwrite_deep_ensemble_splits=True)
+
+        self.assertEqual(splits[:2], [existing_splits[0], existing_splits[2]])
+        self.assertEqual(len(splits), 4)
+        self.assertEqual(splits[2]["train"], ["case_000", "case_001"])
+        self.assertEqual(splits[2]["deep_ensemble_member"], 0)
+        self.assertEqual(splits[3]["deep_ensemble_member"], 1)
+
+    def test_deterministic_output_and_sorted_case_identifiers(self):
+        cases = ["case_c", "case_a", "case_b", "case_d"]
+
+        first = create_or_update_deep_ensemble_splits(None, cases, num_members=1, num_cv_folds=2, seed=12345)
+        second = create_or_update_deep_ensemble_splits(None, cases, num_members=1, num_cv_folds=2, seed=12345)
+
+        self.assertEqual(first, second)
+        self.assertEqual(json.dumps(first, sort_keys=True), json.dumps(second, sort_keys=True))
+        self.assertEqual(first[-1]["train"], sorted(cases))
+        self.assertEqual(first[-1]["val"], sorted(cases))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/nnunetv2/tests/test_deep_ensemble_splits.py
+++ b/nnunetv2/tests/test_deep_ensemble_splits.py
@@ -2,7 +2,9 @@ import json
 import unittest
 from copy import deepcopy
 
-from nnunetv2.utilities.deep_ensemble_splits import create_or_update_deep_ensemble_splits
+from nnunetv2.utilities.deep_ensemble_splits import (
+    create_or_update_deep_ensemble_splits, get_deep_ensemble_fold_indices
+)
 
 
 class TestDeepEnsembleSplits(unittest.TestCase):
@@ -85,6 +87,29 @@ class TestDeepEnsembleSplits(unittest.TestCase):
         self.assertEqual(json.dumps(first, sort_keys=True), json.dumps(second, sort_keys=True))
         self.assertEqual(first[-1]["train"], sorted(cases))
         self.assertEqual(first[-1]["val"], sorted(cases))
+
+    def test_deep_ensemble_split_lists_are_independent(self):
+        splits = create_or_update_deep_ensemble_splits(
+            [], ["case_001", "case_000"], num_members=2)
+
+        splits[0]["train"].append("mutated")
+
+        self.assertEqual(splits[0]["val"], ["case_000", "case_001"])
+        self.assertEqual(splits[1]["train"], ["case_000", "case_001"])
+        self.assertEqual(splits[1]["val"], ["case_000", "case_001"])
+
+    def test_get_deep_ensemble_fold_indices_for_selected_folds(self):
+        splits = [
+            {"train": ["case_000"], "val": ["case_001"]},
+            {"train": ["case_000", "case_001"], "val": ["case_000", "case_001"],
+             "deep_ensemble": True, "deep_ensemble_member": 0},
+            {"train": ["case_001"], "val": ["case_000"]},
+            {"train": ["case_000", "case_001"], "val": ["case_000", "case_001"],
+             "deep_ensemble": True, "deep_ensemble_member": 1},
+        ]
+
+        self.assertEqual(get_deep_ensemble_fold_indices(splits), [1, 3])
+        self.assertEqual(get_deep_ensemble_fold_indices(splits, [0, 1, 4]), [1])
 
 
 if __name__ == "__main__":

--- a/nnunetv2/tests/test_find_best_configuration.py
+++ b/nnunetv2/tests/test_find_best_configuration.py
@@ -1,0 +1,13 @@
+import unittest
+
+from nnunetv2.evaluation.find_best_configuration import find_best_configuration
+
+
+class TestFindBestConfiguration(unittest.TestCase):
+    def test_folds_none_is_rejected_with_clear_error(self):
+        with self.assertRaisesRegex(ValueError, "folds must be a list or tuple"):
+            find_best_configuration("Dataset001_Test", allowed_trained_models=(), folds=None)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/nnunetv2/training/nnUNetTrainer/nnUNetTrainer.py
+++ b/nnunetv2/training/nnUNetTrainer/nnUNetTrainer.py
@@ -638,8 +638,9 @@ class nnUNetTrainer(object):
                 self.print_to_log_file("This split has %d training and %d validation cases."
                                        % (len(tr_keys), len(val_keys)))
                 if is_deep_ensemble_split:
-                    self.print_to_log_file("This split is marked as a deep ensemble split. It uses the full training "
-                                           "set.")
+                    deep_ensemble_member = splits[self.fold].get("deep_ensemble_member", "unknown")
+                    self.print_to_log_file(f"This split is marked as deep ensemble member {deep_ensemble_member}. "
+                                           f"It uses the full training set.")
                     self.print_to_log_file("Validation metrics for this fold are not an unbiased performance estimate.")
             else:
                 self.print_to_log_file("INFO: You requested fold %d for training but splits "

--- a/nnunetv2/training/nnUNetTrainer/nnUNetTrainer.py
+++ b/nnunetv2/training/nnUNetTrainer/nnUNetTrainer.py
@@ -630,11 +630,17 @@ class nnUNetTrainer(object):
                 self.print_to_log_file(f"The split file contains {len(splits)} splits.")
 
             self.print_to_log_file("Desired fold for training: %d" % self.fold)
+            is_deep_ensemble_split = False
             if self.fold < len(splits):
+                is_deep_ensemble_split = bool(splits[self.fold].get("deep_ensemble", False))
                 tr_keys = splits[self.fold]['train']
                 val_keys = splits[self.fold]['val']
                 self.print_to_log_file("This split has %d training and %d validation cases."
                                        % (len(tr_keys), len(val_keys)))
+                if is_deep_ensemble_split:
+                    self.print_to_log_file("This split is marked as a deep ensemble split. It uses the full training "
+                                           "set.")
+                    self.print_to_log_file("Validation metrics for this fold are not an unbiased performance estimate.")
             else:
                 self.print_to_log_file("INFO: You requested fold %d for training but splits "
                                        "contain only %d folds. I am now creating a "
@@ -648,7 +654,7 @@ class nnUNetTrainer(object):
                 val_keys = [keys[i] for i in idx_val]
                 self.print_to_log_file("This random 80:20 split has %d training and %d validation cases."
                                        % (len(tr_keys), len(val_keys)))
-            if any([i in val_keys for i in tr_keys]):
+            if any([i in val_keys for i in tr_keys]) and not is_deep_ensemble_split:
                 self.print_to_log_file('WARNING: Some validation cases are also in the training set. Please check the '
                                        'splits.json or ignore if this is intentional.')
         return tr_keys, val_keys

--- a/nnunetv2/utilities/deep_ensemble_splits.py
+++ b/nnunetv2/utilities/deep_ensemble_splits.py
@@ -1,4 +1,5 @@
 import argparse
+import os.path
 
 
 def _split_is_deep_ensemble(split: dict) -> bool:
@@ -120,14 +121,12 @@ def create_deep_ensemble_splits(dataset_name_or_id: int | str, configuration: st
                                 overwrite_deep_ensemble_splits: bool = False) -> list[dict]:
     from batchgenerators.utilities.file_and_folder_operations import isfile, join, load_json, save_json
 
-    from nnunetv2.utilities.dataset_name_id_conversion import maybe_convert_to_dataset_name
-
     if num_members < 1:
         raise ValueError("num_members must be >= 1.")
 
-    dataset_name = maybe_convert_to_dataset_name(dataset_name_or_id)
     preprocessed_dataset_folder, preprocessed_configuration_folder = _get_preprocessed_configuration_folder(
-        dataset_name, plans_identifier, configuration)
+        dataset_name_or_id, plans_identifier, configuration)
+    dataset_name = os.path.basename(preprocessed_dataset_folder)
     case_identifiers = _get_case_identifiers(preprocessed_configuration_folder)
 
     splits_file = join(preprocessed_dataset_folder, "splits_final.json")

--- a/nnunetv2/utilities/deep_ensemble_splits.py
+++ b/nnunetv2/utilities/deep_ensemble_splits.py
@@ -1,5 +1,4 @@
 import argparse
-from typing import Union
 
 
 def _split_is_deep_ensemble(split: dict) -> bool:
@@ -8,6 +7,11 @@ def _split_is_deep_ensemble(split: dict) -> bool:
 
 def _remove_deep_ensemble_splits(splits: list[dict]) -> list[dict]:
     return [s for s in splits if not _split_is_deep_ensemble(s)]
+
+
+def get_deep_ensemble_fold_indices(splits: list[dict], folds: list[int] | tuple[int, ...] | None = None) -> list[int]:
+    selected_folds = range(len(splits)) if folds is None else folds
+    return [f for f in selected_folds if 0 <= f < len(splits) and _split_is_deep_ensemble(splits[f])]
 
 
 def append_deep_ensemble_splits(splits: list[dict], case_identifiers: list[str], num_members: int,
@@ -31,8 +35,8 @@ def append_deep_ensemble_splits(splits: list[dict], case_identifiers: list[str],
 
     for i in range(num_members):
         updated_splits.append({
-            "train": all_case_identifiers,
-            "val": all_case_identifiers,
+            "train": list(all_case_identifiers),
+            "val": list(all_case_identifiers),
             "deep_ensemble": True,
             "deep_ensemble_member": i,
         })
@@ -61,7 +65,7 @@ def create_or_update_deep_ensemble_splits(splits: list[dict] | None, case_identi
         splits, all_case_identifiers, num_members, overwrite_deep_ensemble_splits=overwrite_deep_ensemble_splits)
 
 
-def _get_preprocessed_dataset_folder(dataset_name_or_id: Union[int, str]) -> str:
+def _get_preprocessed_dataset_folder(dataset_name_or_id: int | str) -> str:
     from batchgenerators.utilities.file_and_folder_operations import isdir, join
 
     from nnunetv2.paths import nnUNet_preprocessed
@@ -75,7 +79,7 @@ def _get_preprocessed_dataset_folder(dataset_name_or_id: Union[int, str]) -> str
     return preprocessed_dataset_folder
 
 
-def _get_preprocessed_configuration_folder(dataset_name_or_id: Union[int, str], plans_identifier: str,
+def _get_preprocessed_configuration_folder(dataset_name_or_id: int | str, plans_identifier: str,
                                            configuration: str) -> tuple[str, str]:
     from batchgenerators.utilities.file_and_folder_operations import isdir, isfile, join
 
@@ -110,7 +114,7 @@ def _get_case_identifiers(preprocessed_configuration_folder: str) -> list[str]:
     return case_identifiers
 
 
-def create_deep_ensemble_splits(dataset_name_or_id: Union[int, str], configuration: str,
+def create_deep_ensemble_splits(dataset_name_or_id: int | str, configuration: str,
                                 plans_identifier: str = "nnUNetPlans", num_members: int = 5,
                                 num_cv_folds: int = 5, seed: int = 12345,
                                 overwrite_deep_ensemble_splits: bool = False) -> list[dict]:
@@ -134,18 +138,16 @@ def create_deep_ensemble_splits(dataset_name_or_id: Union[int, str], configurati
     else:
         splits = None
 
-    non_deep_ensemble_splits = _remove_deep_ensemble_splits(splits) if splits is not None else []
     updated_splits = create_or_update_deep_ensemble_splits(
         splits, case_identifiers, num_members, num_cv_folds, seed,
         overwrite_deep_ensemble_splits=overwrite_deep_ensemble_splits)
-    if splits is None:
-        non_deep_ensemble_splits = _remove_deep_ensemble_splits(updated_splits)
-    appended_fold_indices = list(range(len(non_deep_ensemble_splits), len(updated_splits)))
+    num_non_deep_ensemble_splits = len(updated_splits) - num_members
+    appended_fold_indices = list(range(num_non_deep_ensemble_splits, len(updated_splits)))
 
     save_json(updated_splits, splits_file, sort_keys=False)
 
     print(f"Dataset: {dataset_name}")
-    print(f"Existing non-deep-ensemble folds: {len(non_deep_ensemble_splits)}")
+    print(f"Existing non-deep-ensemble folds: {num_non_deep_ensemble_splits}")
     print(f"Appended deep ensemble folds: {num_members}")
     print(f"Deep ensemble fold indices: {appended_fold_indices}")
     print(f"Wrote split file: {splits_file}")
@@ -156,13 +158,19 @@ def create_deep_ensemble_splits(dataset_name_or_id: Union[int, str], configurati
 
 
 def create_deep_ensemble_splits_entry_point():
+    def positive_int(value: str) -> int:
+        int_value = int(value)
+        if int_value < 1:
+            raise argparse.ArgumentTypeError("must be >= 1")
+        return int_value
+
     parser = argparse.ArgumentParser(
         "Create or update nnU-Net splits_final.json with full-training-set deep ensemble folds.")
     parser.add_argument("dataset_name_or_id", type=str, help="Dataset name or ID.")
     parser.add_argument("configuration", type=str, help="nnU-Net configuration, for example 2d or 3d_fullres.")
     parser.add_argument("-p", "--plans_identifier", default="nnUNetPlans", required=False,
                         help="Plans identifier. Default: nnUNetPlans")
-    parser.add_argument("--num_members", type=int, default=5, required=False,
+    parser.add_argument("--num_members", type=positive_int, default=5, required=False,
                         help="Number of deep ensemble folds to append. Default: 5")
     parser.add_argument("--num_cv_folds", type=int, default=5, required=False,
                         help="Number of CV folds to create if splits_final.json does not exist. Default: 5")

--- a/nnunetv2/utilities/deep_ensemble_splits.py
+++ b/nnunetv2/utilities/deep_ensemble_splits.py
@@ -1,0 +1,181 @@
+import argparse
+from typing import Union
+
+
+def _split_is_deep_ensemble(split: dict) -> bool:
+    return bool(split.get("deep_ensemble", False))
+
+
+def _remove_deep_ensemble_splits(splits: list[dict]) -> list[dict]:
+    return [s for s in splits if not _split_is_deep_ensemble(s)]
+
+
+def append_deep_ensemble_splits(splits: list[dict], case_identifiers: list[str], num_members: int,
+                                overwrite_deep_ensemble_splits: bool = False) -> list[dict]:
+    if num_members < 1:
+        raise ValueError("num_members must be >= 1.")
+    if not isinstance(splits, list):
+        raise ValueError("splits must be a list of dictionaries.")
+    if any(not isinstance(s, dict) for s in splits):
+        raise ValueError("splits must be a list of dictionaries.")
+    if len(case_identifiers) == 0:
+        raise ValueError("case_identifiers must not be empty.")
+
+    existing_deep_ensemble_splits = [s for s in splits if _split_is_deep_ensemble(s)]
+    if len(existing_deep_ensemble_splits) > 0 and not overwrite_deep_ensemble_splits:
+        raise RuntimeError("splits already contains deep ensemble splits. Use overwrite_deep_ensemble_splits=True "
+                           "to replace them.")
+
+    all_case_identifiers = sorted(case_identifiers)
+    updated_splits = _remove_deep_ensemble_splits(splits) if overwrite_deep_ensemble_splits else list(splits)
+
+    for i in range(num_members):
+        updated_splits.append({
+            "train": all_case_identifiers,
+            "val": all_case_identifiers,
+            "deep_ensemble": True,
+            "deep_ensemble_member": i,
+        })
+
+    return updated_splits
+
+
+def create_or_update_deep_ensemble_splits(splits: list[dict] | None, case_identifiers: list[str],
+                                          num_members: int = 5, num_cv_folds: int = 5, seed: int = 12345,
+                                          overwrite_deep_ensemble_splits: bool = False) -> list[dict]:
+    all_case_identifiers = sorted(case_identifiers)
+    if len(all_case_identifiers) == 0:
+        raise ValueError("case_identifiers must not be empty.")
+
+    if splits is None:
+        if num_cv_folds < 2:
+            raise ValueError("num_cv_folds must be >= 2 when creating cross-validation splits.")
+        if num_cv_folds > len(all_case_identifiers):
+            raise ValueError(f"Cannot create {num_cv_folds} cross-validation folds from "
+                             f"{len(all_case_identifiers)} cases.")
+        from nnunetv2.utilities.crossval_split import generate_crossval_split
+
+        splits = generate_crossval_split(all_case_identifiers, seed=seed, n_splits=num_cv_folds)
+
+    return append_deep_ensemble_splits(
+        splits, all_case_identifiers, num_members, overwrite_deep_ensemble_splits=overwrite_deep_ensemble_splits)
+
+
+def _get_preprocessed_dataset_folder(dataset_name_or_id: Union[int, str]) -> str:
+    from batchgenerators.utilities.file_and_folder_operations import isdir, join
+
+    from nnunetv2.paths import nnUNet_preprocessed
+    from nnunetv2.utilities.dataset_name_id_conversion import maybe_convert_to_dataset_name
+
+    dataset_name = maybe_convert_to_dataset_name(dataset_name_or_id)
+    preprocessed_dataset_folder = join(nnUNet_preprocessed, dataset_name)
+    if not isdir(preprocessed_dataset_folder):
+        raise RuntimeError(f"Preprocessed dataset folder does not exist: {preprocessed_dataset_folder}. "
+                           f"Run nnUNetv2_plan_and_preprocess first.")
+    return preprocessed_dataset_folder
+
+
+def _get_preprocessed_configuration_folder(dataset_name_or_id: Union[int, str], plans_identifier: str,
+                                           configuration: str) -> tuple[str, str]:
+    from batchgenerators.utilities.file_and_folder_operations import isdir, isfile, join
+
+    from nnunetv2.utilities.plans_handling.plans_handler import PlansManager
+
+    preprocessed_dataset_folder = _get_preprocessed_dataset_folder(dataset_name_or_id)
+    plans_file = join(preprocessed_dataset_folder, plans_identifier + ".json")
+    if not isfile(plans_file):
+        raise RuntimeError(f"Plans file does not exist: {plans_file}")
+
+    plans_manager = PlansManager(plans_file)
+    configuration_manager = plans_manager.get_configuration(configuration)
+    preprocessed_configuration_folder = join(preprocessed_dataset_folder, configuration_manager.data_identifier)
+    if not isdir(preprocessed_configuration_folder):
+        raise RuntimeError(f"Preprocessed data folder for configuration {configuration} of plans identifier "
+                           f"{plans_identifier} does not exist: {preprocessed_configuration_folder}. "
+                           f"Run preprocessing for this configuration first.")
+    return preprocessed_dataset_folder, preprocessed_configuration_folder
+
+
+def _get_case_identifiers(preprocessed_configuration_folder: str) -> list[str]:
+    from batchgenerators.utilities.file_and_folder_operations import subfiles
+
+    from nnunetv2.training.dataloading.nnunet_dataset import infer_dataset_class
+
+    if len(subfiles(preprocessed_configuration_folder, join=False)) == 0:
+        raise RuntimeError(f"No preprocessed cases found in {preprocessed_configuration_folder}.")
+    dataset_class = infer_dataset_class(preprocessed_configuration_folder)
+    case_identifiers = sorted(dataset_class.get_identifiers(preprocessed_configuration_folder))
+    if len(case_identifiers) == 0:
+        raise RuntimeError(f"No preprocessed cases found in {preprocessed_configuration_folder}.")
+    return case_identifiers
+
+
+def create_deep_ensemble_splits(dataset_name_or_id: Union[int, str], configuration: str,
+                                plans_identifier: str = "nnUNetPlans", num_members: int = 5,
+                                num_cv_folds: int = 5, seed: int = 12345,
+                                overwrite_deep_ensemble_splits: bool = False) -> list[dict]:
+    from batchgenerators.utilities.file_and_folder_operations import isfile, join, load_json, save_json
+
+    from nnunetv2.utilities.dataset_name_id_conversion import maybe_convert_to_dataset_name
+
+    if num_members < 1:
+        raise ValueError("num_members must be >= 1.")
+
+    dataset_name = maybe_convert_to_dataset_name(dataset_name_or_id)
+    preprocessed_dataset_folder, preprocessed_configuration_folder = _get_preprocessed_configuration_folder(
+        dataset_name, plans_identifier, configuration)
+    case_identifiers = _get_case_identifiers(preprocessed_configuration_folder)
+
+    splits_file = join(preprocessed_dataset_folder, "splits_final.json")
+    if isfile(splits_file):
+        splits = load_json(splits_file)
+        if not isinstance(splits, list):
+            raise ValueError(f"Expected {splits_file} to contain a list of splits.")
+    else:
+        splits = None
+
+    non_deep_ensemble_splits = _remove_deep_ensemble_splits(splits) if splits is not None else []
+    updated_splits = create_or_update_deep_ensemble_splits(
+        splits, case_identifiers, num_members, num_cv_folds, seed,
+        overwrite_deep_ensemble_splits=overwrite_deep_ensemble_splits)
+    if splits is None:
+        non_deep_ensemble_splits = _remove_deep_ensemble_splits(updated_splits)
+    appended_fold_indices = list(range(len(non_deep_ensemble_splits), len(updated_splits)))
+
+    save_json(updated_splits, splits_file, sort_keys=False)
+
+    print(f"Dataset: {dataset_name}")
+    print(f"Existing non-deep-ensemble folds: {len(non_deep_ensemble_splits)}")
+    print(f"Appended deep ensemble folds: {num_members}")
+    print(f"Deep ensemble fold indices: {appended_fold_indices}")
+    print(f"Wrote split file: {splits_file}")
+    print("WARNING: Deep ensemble folds use all training cases. Their validation metrics are biased and must not be "
+          "used for model selection or performance estimation.")
+
+    return updated_splits
+
+
+def create_deep_ensemble_splits_entry_point():
+    parser = argparse.ArgumentParser(
+        "Create or update nnU-Net splits_final.json with full-training-set deep ensemble folds.")
+    parser.add_argument("dataset_name_or_id", type=str, help="Dataset name or ID.")
+    parser.add_argument("configuration", type=str, help="nnU-Net configuration, for example 2d or 3d_fullres.")
+    parser.add_argument("-p", "--plans_identifier", default="nnUNetPlans", required=False,
+                        help="Plans identifier. Default: nnUNetPlans")
+    parser.add_argument("--num_members", type=int, default=5, required=False,
+                        help="Number of deep ensemble folds to append. Default: 5")
+    parser.add_argument("--num_cv_folds", type=int, default=5, required=False,
+                        help="Number of CV folds to create if splits_final.json does not exist. Default: 5")
+    parser.add_argument("--seed", type=int, default=12345, required=False,
+                        help="Seed for CV split creation if splits_final.json does not exist. Default: 12345")
+    parser.add_argument("--overwrite_deep_ensemble_splits", action="store_true", required=False,
+                        help="Remove existing splits marked as deep ensemble splits before appending new ones.")
+    args = parser.parse_args()
+
+    create_deep_ensemble_splits(args.dataset_name_or_id, args.configuration, args.plans_identifier,
+                                args.num_members, args.num_cv_folds, args.seed,
+                                args.overwrite_deep_ensemble_splits)
+
+
+if __name__ == "__main__":
+    create_deep_ensemble_splits_entry_point()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ nnUNetv2_move_plans_between_datasets = "nnunetv2.experiment_planning.plans_for_p
 nnUNetv2_evaluate_folder = "nnunetv2.evaluation.evaluate_predictions:evaluate_folder_entry_point"
 nnUNetv2_evaluate_simple = "nnunetv2.evaluation.evaluate_predictions:evaluate_simple_entry_point"
 nnUNetv2_convert_MSD_dataset = "nnunetv2.dataset_conversion.convert_MSD_dataset:entry_point"
+nnUNetv2_create_deep_ensemble_splits = "nnunetv2.utilities.deep_ensemble_splits:create_deep_ensemble_splits_entry_point"
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
This PR adds a small opt-in utility for training deep ensemble members using nnU-Net’s existing fold infrastructure.

It does not change the training loop, architecture, loss functions, checkpoint format, inference defaults, or model-selection defaults. The new command only creates or updates `splits_final.json` by preserving existing CV folds and appending marked full-training-set folds for deep ensemble training.

Users can then train those members with the existing command:

```bash
nnUNetv2_train DATASET CONFIGURATION FOLD
```

and explicitly select them for inference with `nnUNetv2_predict -f`.

The PR also adds documentation explaining the difference between CV ensembles and deep ensembles for uncertainty estimation, warns that validation metrics from full-training-set deep ensemble folds are biased, and includes lightweight tests for split generation behavior.