### PR TITLE
Feature Request: Add MLflow logging backend alongside existing W&B support

### DIFF
--- a/documentation/explanation_logging.md
+++ b/documentation/explanation_logging.md
@@ -12,7 +12,7 @@ Logging in nnU-Net is intentionally simple and centralized in
 The trainer talks to one object, `MetaLogger`, and `MetaLogger` fans out logs to:
 
 - `LocalLogger` (always enabled): the source of truth for training curves, checkpoint logging state, and `progress.png`
-- optional external loggers (currently `WandbLogger`)
+- optional external loggers (currently `WandbLogger` and `MlflowLogger`)
 
 This keeps training code clean while still allowing external tracking backends.
 
@@ -57,6 +57,49 @@ Notes:
 
 - `nnUNet_wandb_enabled` accepts `0/1` and `false/true` (case-insensitive). Other values raise an error.
 - When resuming (`--c`), W&B resume metadata in `fold_x/wandb/latest-run` is reused and duplicate older steps are skipped.
+
+## How to enable MLflow
+
+1. Install MLflow:
+
+```bash
+pip install mlflow
+```
+
+2. Enable the backend via environment variables:
+
+```bash
+export nnUNet_mlflow_enabled=1
+export nnUNet_mlflow_experiment=nnunet
+export nnUNet_mlflow_tracking_uri=mlruns    # or a remote URI such as http://myserver:5000
+export nnUNet_mlflow_system_metrics=0       # or 1 to measure system metrics -> requires: pip install psutil (+ pynvml for NVIDIA GPU metrics)
+```
+
+3. Run training normally:
+
+```bash
+nnUNetv2_train DATASET_NAME_OR_ID 3d_fullres 0
+```
+
+Notes:
+
+- `nnUNet_mlflow_enabled` accepts `0/1` and `false/true` (case-insensitive). Other values raise an error.
+- If `mlflow` is not installed but the env var is set, a warning is printed and training continues with local logging only — it does not crash.
+- The run ID is persisted in `fold_x/mlflow/run_id.txt`. When resuming (`--c`), that ID is reused so metrics append to the same run regardless of how many checkpoint restarts a single model training requires.
+- `nnUNet_mlflow_tracking_uri` accepts any URI supported by MLflow: a local directory, `http://...` for a remote tracking server, or a `databricks` URI.
+- For a **remote server**, start it with `mlflow server` (not `mlflow ui` — the UI is read-only and cannot accept metric writes): `mlflow server --backend-store-uri /path/to/mlruns --host 0.0.0.0 --port 5000`
+- Each run is automatically named `DatasetXXX_Name__configuration__fold_X` and tagged with `dataset`, `configuration`, `fold`, and `trainer` for easy filtering in the MLflow UI.
+- The run is ended cleanly via `atexit` even if training crashes, so runs do not stay stuck in `RUNNING` state.
+
+### Optional: system metrics
+
+To also log CPU usage, memory, and GPU utilisation per epoch:
+
+```bash
+export nnUNet_mlflow_system_metrics=1
+```
+
+This calls `mlflow.enable_system_metrics_logging()` and requires `psutil` (`pip install psutil`). GPU metrics additionally require `pynvml` for NVIDIA GPUs.
 
 ## How to integrate a custom logger
 

--- a/documentation/reference/logging.md
+++ b/documentation/reference/logging.md
@@ -7,7 +7,7 @@ This page summarizes how training logging works in nnU-Net v2.
 Training logs are routed through `MetaLogger`, which fans out to:
 
 - `LocalLogger`: always enabled
-- optional external loggers such as `WandbLogger`
+- optional external loggers such as `WandbLogger` and `MlflowLogger`
 
 The local logger is the source of truth for training curves and `progress.png`.
 
@@ -52,6 +52,40 @@ nnUNetv2_train DATASET_NAME_OR_ID 3d_fullres 0
 ```
 
 `nnUNet_wandb_mode` can also be `offline`.
+
+## Enable MLflow
+
+1. Install MLflow:
+
+```bash
+pip install mlflow
+```
+
+2. Set the environment variables:
+
+```bash
+export nnUNet_mlflow_enabled=1
+export nnUNet_mlflow_experiment=nnunet
+export nnUNet_mlflow_tracking_uri=mlruns    # or http://myserver:5000
+export nnUNet_mlflow_system_metrics=0       # or 1 to measure system metrics -> requires: pip install psutil (+ pynvml for NVIDIA GPU metrics)
+```
+
+3. Run training normally:
+
+```bash
+nnUNetv2_train DATASET_NAME_OR_ID 3d_fullres 0
+```
+
+`nnUNet_mlflow_tracking_uri` accepts any URI supported by MLflow: a local directory, `http://...` for a remote tracking server, or a `databricks` URI.
+
+**Behaviour notes:**
+
+- If `mlflow` is not installed but the env var is set, a warning is printed and training continues — it does not crash.
+- For a remote server, use `mlflow server --host 0.0.0.0 --port 5000` on the host — `mlflow ui` is read-only and will reject writes.
+- Each run is named `DatasetXXX_Name__configuration__fold_X` automatically.
+- Runs are tagged with `dataset`, `configuration`, `fold`, and `trainer` for filtering in the UI.
+- The run ID is saved in `fold_x/mlflow/run_id.txt` and reused on resume (`--c`), so all checkpoint restarts for a single model append to the same run.
+- Runs are ended cleanly via `atexit` even on crash, so they do not remain stuck in `RUNNING` state.
 
 ## Custom loggers
 

--- a/nnunetv2/training/logging/nnunet_logger.py
+++ b/nnunetv2/training/logging/nnunet_logger.py
@@ -1,3 +1,4 @@
+import atexit
 import matplotlib
 from batchgenerators.utilities.file_and_folder_operations import join
 
@@ -13,6 +14,11 @@ try:
     import wandb
 except ImportError:
     wandb = None
+
+try:
+    import mlflow
+except ImportError:
+    mlflow = None
 
 
 def get_cluster_job_id():
@@ -45,6 +51,8 @@ class MetaLogger(object):
         self.local_logger = LocalLogger(verbose)
         if self._is_logger_enabled("nnUNet_wandb_enabled"):
             self.loggers.append(WandbLogger(output_folder, resume))
+        if self._is_logger_enabled("nnUNet_mlflow_enabled"):
+            self.loggers.append(MlflowLogger(output_folder, resume))
 
     def update_config(self, config: dict):
         """Add a new or update an existing experiment configuration to the logger.
@@ -301,3 +309,120 @@ class WandbLogger:
             value: Summary value to store.
         """
         self.run.summary[key] = value
+
+
+class MlflowLogger:
+    """MLflow logger for nnU-Net training runs.
+
+    Environment Variables:
+        nnUNet_mlflow_enabled:        Whether MLflow logger is enabled (default: 0 -> Disabled).
+        nnUNet_mlflow_experiment:     MLflow experiment name (default: "nnunet").
+        nnUNet_mlflow_tracking_uri:   MLflow tracking server URI (default: "mlruns").
+        nnUNet_mlflow_system_metrics: Whether to log CPU/GPU/memory system metrics (default: 0 -> Disabled).
+    """
+
+    def __init__(self, output_folder, resume):
+        """Initialize an MLflow run and handle resume behavior.
+
+        Args:
+            output_folder: Directory where MLflow run ID is persisted.
+            resume: Whether to resume a previous MLflow run if present.
+        """
+        if mlflow is None:
+            print('WARNING: nnU-Net MLflow logging is enabled (nnUNet_mlflow_enabled=1) but mlflow is not '
+                  'installed. Continuing without MLflow logging. Install with: pip install mlflow')
+            self._disabled = True
+            return
+
+        self._disabled = False
+        self.output_folder = Path(output_folder)
+        self.resume = resume
+        self.experiment = os.getenv('nnUNet_mlflow_experiment', 'nnunet')
+        self.tracking_uri = os.getenv('nnUNet_mlflow_tracking_uri', 'mlruns')
+
+        if str(os.getenv('nnUNet_mlflow_system_metrics', '0')) in ('1', 'True', 'true'):
+            mlflow.enable_system_metrics_logging()
+
+        mlflow.set_tracking_uri(self.tracking_uri)
+        mlflow.set_experiment(self.experiment)
+
+        # derive a stable run name and searchable tags from the output folder structure:
+        # .../DatasetXXX_Name/Trainer__Plans__Config/fold_X
+        parts = self.output_folder.parts
+        dataset = parts[-3] if len(parts) >= 3 else 'unknown'
+        trainer_plans_config = parts[-2] if len(parts) >= 2 else 'unknown'
+        fold = parts[-1] if len(parts) >= 1 else 'unknown'
+        config_segments = trainer_plans_config.split('__')
+        trainer = config_segments[0]
+        configuration = config_segments[-1] if len(config_segments) >= 2 else trainer_plans_config
+        run_name = f'{dataset}__{configuration}__{fold}'
+
+        run_id = None
+        mlflow_dir = self.output_folder / 'mlflow'
+        run_id_file = mlflow_dir / 'run_id.txt'
+
+        if mlflow_dir.is_dir():
+            if self.resume:
+                run_id = run_id_file.read_text().strip()
+            else:
+                shutil.rmtree(str(mlflow_dir))
+
+        # run_name is ignored by MLflow when resuming an existing run_id
+        self.run = mlflow.start_run(run_id=run_id, run_name=run_name)
+        mlflow.log_param('JobID', get_cluster_job_id())
+        mlflow.set_tags({
+            'dataset': dataset,
+            'configuration': configuration,
+            'fold': fold,
+            'trainer': trainer,
+        })
+
+        mlflow_dir.mkdir(parents=True, exist_ok=True)
+        run_id_file.write_text(self.run.info.run_id)
+
+        self._last_logged_step = -1
+        atexit.register(self._end_run)
+
+    def _end_run(self):
+        if not self._disabled and mlflow.active_run() is not None:
+            mlflow.end_run()
+
+    def update_config(self, config: dict):
+        """Update MLflow run parameters with training metadata.
+
+        Args:
+            config: Configuration values to log as MLflow params.
+        """
+        if self._disabled:
+            return
+        try:
+            mlflow.log_params(config)
+        except mlflow.exceptions.MlflowException:
+            # on resume, params already exist; log as tags instead to avoid crash
+            mlflow.set_tags({f'config/{k}': v for k, v in config.items()})
+
+    def log(self, key, value, step: int):
+        """Log a scalar metric to MLflow.
+
+        Args:
+            key: Metric or field name.
+            value: Value to log.
+            step: Step index (typically epoch).
+        """
+        if self._disabled:
+            return
+        if step != self._last_logged_step:
+            self.log_summary('current_epoch', step)
+            self._last_logged_step = step
+        mlflow.log_metric(key, value, step=step)
+
+    def log_summary(self, key, value):
+        """Write a summary value to MLflow as a tag.
+
+        Args:
+            key: Metric or field name.
+            value: Summary value to store.
+        """
+        if self._disabled:
+            return
+        mlflow.set_tag(key, value)


### PR DESCRIPTION
Hi @FabianIsensee!

I've been using MLflow to track my nnUNet training runs and thought it might be useful to others. 

Hospitals/HPC environments where data cannot leave the institution a self-hosted, open-source option is preferred/expected. (this is my case)

I've added a MLflowLogger class in nnunetv2/training/logging/nnunet_logger.py and updated the docs.

Happy to adjust anything to fit the project better!