### PR TITLE
Scope intel_macos extra constraints to macOS via platform marker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,8 +86,8 @@ dev = [
     "pre-commit"
 ]
 intel_macos = [
-    "torch<2.3",
-    "numpy<2",
+    "torch<2.3 ; platform_system == 'Darwin'",
+    "numpy<2 ; platform_system == 'Darwin'",
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
## Problem

The `intel_macos` optional-dependency group pins `torch<2.3` and `numpy<2` **without an environment marker**:

```toml
intel_macos = [
    "torch<2.3",
    "numpy<2",
]
```

Because the group is opt-in, this is harmless for a plain `pip install nnunetv2`. But in resolvers that solve **all extras together** against a single universal lock — e.g. **uv workspaces** (common when nnU-Net is vendored as an editable submodule) or pip-tools universal resolution — the caps participate in the resolution for *every* platform. The unmarked `torch<2.3` then leaks onto non-macOS hosts and silently holds torch at `2.2.x` even on Linux/CUDA machines that opted into **no** extras.

Concretely, on a Linux + A100 (CUDA 12.8) host this forces `torch 2.2.2+cu121` / `torchvision 0.17.2` / `numpy 1.26.4` and the 2023-era `nvidia-*-cu12` wheels, instead of the current stack the base requirement (`torch>=2.1.2,!=2.9.*`) would otherwise allow.

## Fix

Scope the constraints to the platform the extra is named for:

```toml
intel_macos = [
    "torch<2.3 ; platform_system == 'Darwin'",
    "numpy<2 ; platform_system == 'Darwin'",
]
```

No behavior change for Intel-mac users who opt into the extra; the caps simply no longer leak onto other platforms during universal resolution.