### PR TITLE
Fix UnboundLocalError when passing a dict to load_checkpoint

### DIFF
--- a/nnunetv2/training/nnUNetTrainer/nnUNetTrainer.py
+++ b/nnunetv2/training/nnUNetTrainer/nnUNetTrainer.py
@@ -1217,12 +1217,12 @@ class nnUNetTrainer(object):
             else:
                 self.print_to_log_file('No checkpoint written, checkpointing is disabled')
 
-    def load_checkpoint(self, filename_or_checkpoint: Union[dict, str]) -> None:
+    def load_checkpoint(self, checkpoint: Union[dict, str]) -> None:
         if not self.was_initialized:
             self.initialize()
 
-        if isinstance(filename_or_checkpoint, str):
-            checkpoint = torch.load(filename_or_checkpoint, map_location=self.device, weights_only=False)
+        if isinstance(checkpoint, str):
+            checkpoint = torch.load(checkpoint, map_location=self.device, weights_only=False)
         # if state dict comes from nn.DataParallel but we use non-parallel model here then the state dict keys do not
         # match. Use heuristic to make it match
         new_state_dict = {}

--- a/nnunetv2/training/nnUNetTrainer/variants/lr_schedule/nnUNetTrainer_warmup.py
+++ b/nnunetv2/training/nnUNetTrainer/variants/lr_schedule/nnUNetTrainer_warmup.py
@@ -74,7 +74,7 @@ class nnUNetTrainer_warmup(nnUNetTrainer):
 
         super().on_train_epoch_start()
 
-    def load_checkpoint(self, filename_or_checkpoint: Union[dict, str]) -> None:
+    def load_checkpoint(self, checkpoint: Union[dict, str]) -> None:
         """
         We need to overwrite that entire function because we need to fiddle the correct optimizer in between
         loading the checkpoint and applying the optimizer states. Yuck.
@@ -82,8 +82,8 @@ class nnUNetTrainer_warmup(nnUNetTrainer):
         if not self.was_initialized:
             self.initialize()
 
-        if isinstance(filename_or_checkpoint, str):
-            checkpoint = torch.load(filename_or_checkpoint, map_location=self.device)
+        if isinstance(checkpoint, str):
+            checkpoint = torch.load(checkpoint, map_location=self.device)
         # if state dict comes from nn.DataParallel but we use non-parallel model here then the state dict keys do not
         # match. Use heuristic to make it match
         new_state_dict = {}

--- a/nnunetv2/training/nnUNetTrainer/variants/lr_schedule/nnUNetTrainer_warmup.py
+++ b/nnunetv2/training/nnUNetTrainer/variants/lr_schedule/nnUNetTrainer_warmup.py
@@ -83,7 +83,7 @@ class nnUNetTrainer_warmup(nnUNetTrainer):
             self.initialize()
 
         if isinstance(checkpoint, str):
-            checkpoint = torch.load(checkpoint, map_location=self.device)
+            checkpoint = torch.load(checkpoint, map_location=self.device, weights_only=False)
         # if state dict comes from nn.DataParallel but we use non-parallel model here then the state dict keys do not
         # match. Use heuristic to make it match
         new_state_dict = {}


### PR DESCRIPTION
### Description
This PR fixes a bug in `nnUNetTrainer.load_checkpoint` where passing a checkpoint as a dictionary (as permitted by the `Union[dict, str]` type hint) results in an `UnboundLocalError`. 

Previously, if a dictionary was passed, the `isinstance(filename_or_checkpoint, str)` block was skipped, leaving the local variable `checkpoint` undefined before the subsequent `for` loop attempted to iterate over `checkpoint['network_weights']`.

### The Fix
Renamed the input argument from `filename_or_checkpoint` to `checkpoint`. 
* If a `str` is passed, it loads the file and correctly overwrites the `checkpoint` variable.
* If a `dict` is passed, it bypasses the string check and seamlessly falls through to the rest of the function using the provided dictionary.

This fix was applied to both the base `nnUNetTrainer.py` and the overridden method in `nnUNetTrainer_warmup.py`.

Note:
This description was written by Gemini and me.