### PR TITLE
fix: replace hardcoded __main__ block in predict_from_raw_data.py

### DIFF
--- a/nnunetv2/inference/predict_from_raw_data.py
+++ b/nnunetv2/inference/predict_from_raw_data.py
@@ -1060,40 +1060,4 @@ def predict_entry_point():
 
 
 if __name__ == '__main__':
-    ########################## predict a bunch of files
-    from nnunetv2.paths import nnUNet_results
-
-    predictor = nnUNetPredictor(
-        tile_step_size=0.5,
-        use_gaussian=True,
-        use_mirroring=True,
-        perform_everything_on_device=True,
-        device=torch.device('cuda', 0),
-        verbose=False,
-        verbose_preprocessing=False,
-        allow_tqdm=True
-    )
-    predictor.initialize_from_trained_model_folder(
-        join(nnUNet_results, 'Dataset004_Hippocampus/nnUNetTrainer_5epochs__nnUNetPlans__3d_fullres'),
-        use_folds=(0,),
-        checkpoint_name='checkpoint_final.pth',
-    )
-    # predictor.predict_from_files(join(nnUNet_raw, 'Dataset003_Liver/imagesTs'),
-    #                              join(nnUNet_raw, 'Dataset003_Liver/imagesTs_predlowres'),
-    #                              save_probabilities=False, overwrite=False,
-    #                              num_processes_preprocessing=2, num_processes_segmentation_export=2,
-    #                              folder_with_segs_from_prev_stage=None, num_parts=1, part_id=0)
-    #
-    # # predict a numpy array
-    # from nnunetv2.imageio.simpleitk_reader_writer import SimpleITKIO
-    #
-    # img, props = SimpleITKIO().read_images([join(nnUNet_raw, 'Dataset003_Liver/imagesTr/liver_63_0000.nii.gz')])
-    # ret = predictor.predict_single_npy_array(img, props, None, None, False)
-    #
-    # iterator = predictor.get_data_iterator_from_raw_npy_data([img], None, [props], None, 1)
-    # ret = predictor.predict_from_data_iterator(iterator, False, 1)
-
-    ret = predictor.predict_from_files_sequential(
-        [['/media/isensee/raw_data/nnUNet_raw/Dataset004_Hippocampus/imagesTs/hippocampus_002_0000.nii.gz'], ['/media/isensee/raw_data/nnUNet_raw/Dataset004_Hippocampus/imagesTs/hippocampus_005_0000.nii.gz']],
-        '/home/isensee/temp/tmp', False, True, None
-    )
+    predict_entry_point_modelfolder()


### PR DESCRIPTION
                                                                                                                                                                                              
  Fixes #3052                                                                                                                                                                                           
                                                            
  ## Bug

  The `if __name__ == '__main__':` block (lines 1062–1099) is a leftover developer-testing stub that hardcodes:
  - `Dataset004_Hippocampus/nnUNetTrainer_5epochs__nnUNetPlans__3d_fullres`
  - Local filesystem paths (`/media/isensee/raw_data/...`, `/home/isensee/temp/tmp`)

  This makes `python -m nnunetv2.inference.predict_from_raw_data` unusable for end users.

  ## Fix

  Replace the entire block with a call to `predict_entry_point_modelfolder()` (already defined at line 812), which handles all prediction options via argparse.

  ## Reproduction

  ```python
  python -m nnunetv2.inference.predict_from_raw_data
  # Attempts to load Dataset004_Hippocampus from /media/isensee/... instead of parsing CLI args
