### PR TITLE
Fix --val_best validation without checkpoint_final

### DIFF
--- a/nnunetv2/run/run_training.py
+++ b/nnunetv2/run/run_training.py
@@ -61,7 +61,7 @@ def get_trainer_from_args(dataset_name_or_id: Union[int, str],
 
 
 def maybe_load_checkpoint(nnunet_trainer: nnUNetTrainer, continue_training: bool, validation_only: bool,
-                          pretrained_weights_file: str = None):
+                          pretrained_weights_file: str = None, validation_with_best: bool = False):
     if continue_training and pretrained_weights_file is not None:
         raise RuntimeError('Cannot both continue a training AND load pretrained weights. Pretrained weights can only '
                            'be used at the beginning of the training.')
@@ -77,9 +77,14 @@ def maybe_load_checkpoint(nnunet_trainer: nnUNetTrainer, continue_training: bool
                                "continue from. Starting a new training...")
             expected_checkpoint_file = None
     elif validation_only:
-        expected_checkpoint_file = join(nnunet_trainer.output_folder, 'checkpoint_final.pth')
-        if not isfile(expected_checkpoint_file):
-            raise RuntimeError("Cannot run validation because the training is not finished yet!")
+        if validation_with_best:
+            expected_checkpoint_file = join(nnunet_trainer.output_folder, 'checkpoint_best.pth')
+            if not isfile(expected_checkpoint_file):
+                raise RuntimeError("Cannot run validation because checkpoint_best.pth is missing!")
+        else:
+            expected_checkpoint_file = join(nnunet_trainer.output_folder, 'checkpoint_final.pth')
+            if not isfile(expected_checkpoint_file):
+                raise RuntimeError("Cannot run validation because the training is not finished yet!")
     else:
         if pretrained_weights_file is not None:
             if not nnunet_trainer.was_initialized:
@@ -112,7 +117,7 @@ def run_ddp(rank, dataset_name_or_id, configuration, fold, tr, p, disable_checkp
 
     assert not (c and val), 'Cannot set --c and --val flag at the same time. Dummy.'
 
-    maybe_load_checkpoint(nnunet_trainer, c, val, pretrained_weights)
+    maybe_load_checkpoint(nnunet_trainer, c, val, pretrained_weights, val_with_best)
 
     if torch.cuda.is_available():
         cudnn.deterministic = False
@@ -121,7 +126,7 @@ def run_ddp(rank, dataset_name_or_id, configuration, fold, tr, p, disable_checkp
     if not val:
         nnunet_trainer.run_training()
 
-    if val_with_best:
+    if val_with_best and not val:
         nnunet_trainer.load_checkpoint(join(nnunet_trainer.output_folder, 'checkpoint_best.pth'))
     nnunet_trainer.perform_actual_validation(npz)
     cleanup_ddp()
@@ -190,7 +195,7 @@ def run_training(dataset_name_or_id: Union[str, int],
 
         assert not (continue_training and only_run_validation), 'Cannot set --c and --val flag at the same time. Dummy.'
 
-        maybe_load_checkpoint(nnunet_trainer, continue_training, only_run_validation, pretrained_weights)
+        maybe_load_checkpoint(nnunet_trainer, continue_training, only_run_validation, pretrained_weights, val_with_best)
 
         if torch.cuda.is_available():
             cudnn.deterministic = False
@@ -199,7 +204,7 @@ def run_training(dataset_name_or_id: Union[str, int],
         if not only_run_validation:
             nnunet_trainer.run_training()
 
-        if val_with_best:
+        if val_with_best and not only_run_validation:
             nnunet_trainer.load_checkpoint(join(nnunet_trainer.output_folder, 'checkpoint_best.pth'))
         nnunet_trainer.perform_actual_validation(export_validation_probabilities)
 

--- a/nnunetv2/tests/test_run_training.py
+++ b/nnunetv2/tests/test_run_training.py
@@ -1,0 +1,98 @@
+import os
+import unittest
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+import torch
+
+from nnunetv2.run.run_training import maybe_load_checkpoint, run_training
+
+
+class DummyTrainer:
+    def __init__(self, output_folder: str):
+        self.output_folder = output_folder
+        self.disable_checkpointing = False
+        self.events = []
+
+    def load_checkpoint(self, checkpoint_file: str):
+        self.events.append(f"load:{os.path.basename(checkpoint_file)}")
+
+    def run_training(self):
+        self.events.append("train")
+
+    def perform_actual_validation(self, export_probabilities: bool):
+        self.events.append(f"validate:{export_probabilities}")
+
+
+class TestValidationCheckpointLoading(unittest.TestCase):
+    def test_validation_only_loads_final_checkpoint(self):
+        with TemporaryDirectory() as output_folder:
+            open(os.path.join(output_folder, 'checkpoint_final.pth'), 'a').close()
+            trainer = DummyTrainer(output_folder)
+
+            maybe_load_checkpoint(trainer, False, True)
+
+            self.assertEqual(trainer.events, ['load:checkpoint_final.pth'])
+
+    def test_validation_only_with_best_loads_best_without_final(self):
+        with TemporaryDirectory() as output_folder:
+            open(os.path.join(output_folder, 'checkpoint_best.pth'), 'a').close()
+            trainer = DummyTrainer(output_folder)
+
+            maybe_load_checkpoint(trainer, False, True, validation_with_best=True)
+
+            self.assertEqual(trainer.events, ['load:checkpoint_best.pth'])
+
+    def test_validation_only_with_best_reports_missing_best_checkpoint(self):
+        with TemporaryDirectory() as output_folder:
+            trainer = DummyTrainer(output_folder)
+
+            with self.assertRaisesRegex(RuntimeError, 'checkpoint_best.pth is missing'):
+                maybe_load_checkpoint(trainer, False, True, validation_with_best=True)
+
+    def test_run_validation_only_with_best_loads_best_once(self):
+        with TemporaryDirectory() as output_folder:
+            open(os.path.join(output_folder, 'checkpoint_best.pth'), 'a').close()
+            trainer = DummyTrainer(output_folder)
+
+            with patch('nnunetv2.run.run_training.get_trainer_from_args', return_value=trainer), \
+                    patch('nnunetv2.run.run_training.torch.cuda.is_available', return_value=False):
+                run_training(
+                    dataset_name_or_id='999',
+                    configuration='3d_fullres',
+                    fold=0,
+                    plans_identifier='TestPlans',
+                    only_run_validation=True,
+                    val_with_best=True,
+                    device=torch.device('cpu'),
+                )
+
+            self.assertEqual(
+                trainer.events,
+                ['load:checkpoint_best.pth', 'validate:False'],
+            )
+
+    def test_training_with_val_best_still_loads_best_after_training(self):
+        with TemporaryDirectory() as output_folder:
+            trainer = DummyTrainer(output_folder)
+
+            with patch('nnunetv2.run.run_training.get_trainer_from_args', return_value=trainer), \
+                    patch('nnunetv2.run.run_training.torch.cuda.is_available', return_value=False):
+                run_training(
+                    dataset_name_or_id='999',
+                    configuration='3d_fullres',
+                    fold=0,
+                    plans_identifier='TestPlans',
+                    only_run_validation=False,
+                    val_with_best=True,
+                    device=torch.device('cpu'),
+                )
+
+            self.assertEqual(
+                trainer.events,
+                ['train', 'load:checkpoint_best.pth', 'validate:False'],
+            )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## What changed

I had this problem after an interrupted training. `checkpoint_best.pth` was
available, but `--val --val_best` stopped because `checkpoint_final.pth` was
missing.

The problem was that `maybe_load_checkpoint` checked the final checkpoint before
the `val_with_best` code was reached.

This change makes `--val --val_best` load `checkpoint_best.pth` directly. The
normal `--val_best` behavior after training is also kept.

## Tests

I added tests for:

- normal validation with `checkpoint_final.pth`
- validation with only `checkpoint_best.pth`
- missing best checkpoint
- the normal training + `--val_best` path

All 13 unit tests pass and Ruff reports no issue.

Fixes #3056
